### PR TITLE
Compile boost with rpath support

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -93,10 +93,12 @@ RUN export BOOST_VERSION=1.65.1 && \
         --prefix=${BOOST_INSTALL_DIR} \
         && \
     echo "using mpi ;" >> project-config.jam && \
-    ./b2 install \
+    ./b2 \
+        --build-dir=${BOOST_BUILD_DIR} \
+        hardcode-dll-paths=true dll-path=${BOOST_INSTALL_DIR}/lib \
         link=shared \
         variant=release \
-        --build-dir=${BOOST_BUILD_DIR} \
+        install \
         && \
     rm -rf ${BOOST_ARCHIVE} && \
     rm -rf ${BOOST_BUILD_DIR} && \

--- a/ci/compile_and_run.sh
+++ b/ci/compile_and_run.sh
@@ -9,6 +9,7 @@ cmake \
   -D MFMG_ENABLE_ClangFormat=ON \
   -D MFMG_ENABLE_COVERAGE=ON \
   -D MFMG_ENABLE_DOCUMENTATION=OFF \
+  -D DEAL_II_DIR=${DEAL_II_DIR} \
 ../
 make -j12
 ctest -j12 --no-compress-output -T Test


### PR DESCRIPTION
By default, Boost does not support rpath. This is a problem if a boost library
depends on another one (eg. boost.mpi depends on boost.serialization) and boost
lib is not in the LD_LIBRARY_PATH.