### PR TITLE
Fix a bug when using multiple eigenvectors per agglomerate

### DIFF
--- a/include/mfmg/amge_host.hpp
+++ b/include/mfmg/amge_host.hpp
@@ -128,7 +128,8 @@ private:
   compute_restriction_sparsity_pattern(
       std::vector<dealii::Vector<double>> const &eigenvectors,
       std::vector<std::vector<dealii::types::global_dof_index>> const
-          &dof_indices_maps) const;
+          &dof_indices_maps,
+      std::vector<unsigned int> const &n_local_eigenvectors) const;
 };
 }
 

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(hierarchy_2d)
     solution[index] = distribution(generator);
 
   auto params = std::make_shared<boost::property_tree::ptree>();
-  params->put("eigensolver: number of eigenvectors", 1);
+  params->put("eigensolver: number of eigenvectors", 2);
   params->put("eigensolver: tolerance", 1e-14);
   params->put("preconditioner: type", "Gauss-Seidel");
   params->put("is preconditioner", false);


### PR DESCRIPTION
With two eigenvalues we get
- Grid complexity: 1.47
- Operator complexity:  1.9
- Convergence rate: 0.1

So we have the same results as them except for the convergence rate. We have 0.10 and they have 0.04. 

Relates to #31 
