### PR TITLE
Operator refactor

### DIFF
--- a/include/mfmg/amge_host.hpp
+++ b/include/mfmg/amge_host.hpp
@@ -16,7 +16,7 @@
 
 namespace mfmg
 {
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 class AMGe_host : public AMGe<dim, VectorType>
 {
 public:
@@ -50,7 +50,7 @@ public:
       std::map<typename dealii::Triangulation<dim>::active_cell_iterator,
                typename dealii::DoFHandler<dim>::active_cell_iterator> const
           &patch_to_global_map,
-      const MeshEvaluator &evaluator) const;
+      MeshEvaluator const &evaluator) const;
 
   /**
    * Compute the restriction sparse matrix. The rows of the matrix are
@@ -105,7 +105,7 @@ private:
    * independent set of data.
    */
   void local_worker(unsigned int const n_eigenvectors, double const tolerance,
-                    const MeshEvaluator &evalute,
+                    MeshEvaluator const &evalute,
                     std::vector<unsigned int>::iterator const &agg_id,
                     ScratchData &scratch_data, CopyData &copy_data);
 

--- a/include/mfmg/amge_host.templates.hpp
+++ b/include/mfmg/amge_host.templates.hpp
@@ -27,7 +27,7 @@
 
 namespace mfmg
 {
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 AMGe_host<dim, MeshEvaluator, VectorType>::AMGe_host(
     MPI_Comm comm, dealii::DoFHandler<dim> const &dof_handler,
     std::string const eigensolver_type)
@@ -36,7 +36,7 @@ AMGe_host<dim, MeshEvaluator, VectorType>::AMGe_host(
 {
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 std::tuple<std::vector<std::complex<double>>,
            std::vector<dealii::Vector<double>>,
            std::vector<typename VectorType::value_type>,
@@ -141,7 +141,7 @@ AMGe_host<dim, MeshEvaluator, VectorType>::compute_local_eigenvectors(
                          dof_indices_map);
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 void AMGe_host<dim, MeshEvaluator, VectorType>::
     compute_restriction_sparse_matrix(
         std::vector<dealii::Vector<double>> const &eigenvectors,
@@ -237,7 +237,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::
 #endif
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
     std::array<unsigned int, dim> const &agglomerate_dim,
     unsigned int const n_eigenvectors, double const tolerance,
@@ -278,10 +278,10 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
       *system_sparse_matrix, restriction_sparse_matrix);
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 void AMGe_host<dim, MeshEvaluator, VectorType>::local_worker(
     unsigned int const n_eigenvectors, double const tolerance,
-    const MeshEvaluator &evaluator,
+    MeshEvaluator const &evaluator,
     std::vector<unsigned int>::iterator const &agg_id, ScratchData &,
     CopyData &copy_data)
 {
@@ -301,7 +301,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::local_worker(
                                  agglomerate_to_global_tria_map, evaluator);
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 void AMGe_host<dim, MeshEvaluator, VectorType>::copy_local_to_global(
     CopyData const &copy_data,
     std::vector<dealii::Vector<double>> &eigenvectors,
@@ -319,7 +319,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::copy_local_to_global(
   n_local_eigenvectors.push_back(copy_data.local_eigenvectors.size());
 }
 
-template <int dim, class MeshEvaluator, typename VectorType>
+template <int dim, typename MeshEvaluator, typename VectorType>
 dealii::TrilinosWrappers::SparsityPattern
 AMGe_host<dim, MeshEvaluator, VectorType>::compute_restriction_sparsity_pattern(
     std::vector<dealii::Vector<double>> const &eigenvectors,

--- a/include/mfmg/amge_host.templates.hpp
+++ b/include/mfmg/amge_host.templates.hpp
@@ -176,7 +176,6 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::
 
   // Build the restriction sparse matrix
   restriction_sparse_matrix.reinit(restriction_sp);
-  unsigned int const n_local_rows(eigenvectors.size());
   std::pair<dealii::types::global_dof_index,
             dealii::types::global_dof_index> const local_range =
       restriction_sp.local_range();
@@ -216,7 +215,6 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::
   pos = 0;
   for (unsigned int i = 0; i < n_agglomerates; ++i)
   {
-    unsigned int const n_local_eig = n_local_eigenvectors[i];
     unsigned int const n_elem = eigenvectors[pos].size();
     for (unsigned int j = 0; j < n_elem; ++j)
     {

--- a/include/mfmg/amge_host.templates.hpp
+++ b/include/mfmg/amge_host.templates.hpp
@@ -13,6 +13,7 @@
 #define AMGE_HOST_TEMPLATES_HPP
 
 #include <mfmg/amge_host.hpp>
+#include <mfmg/dealii_adapters.hpp>
 
 #include <deal.II/base/work_stream.h>
 #include <deal.II/dofs/dof_accessor.h>

--- a/include/mfmg/concepts.hpp
+++ b/include/mfmg/concepts.hpp
@@ -14,12 +14,15 @@
 
 #include <mfmg/exceptions.hpp>
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <memory>
+#include <mpi.h>
 
 namespace mfmg
 {
 
-template <class VectorType>
+template <typename VectorType>
 class Operator
 {
 public:
@@ -27,16 +30,19 @@ public:
   using vector_type = VectorType;
 
 public:
-  void apply(const vector_type &x, vector_type &y) const;
-  std::shared_ptr<operator_type> transpose() const;
-  std::shared_ptr<operator_type> multiply(const operator_type &b) const;
+  virtual size_t m() const = 0;
+  virtual size_t n() const = 0;
+  virtual void apply(vector_type const &x, vector_type &y) const = 0;
+  virtual std::shared_ptr<operator_type> transpose() const = 0;
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &b) const = 0;
 
-  std::shared_ptr<vector_type> build_domain_vector() const;
-  std::shared_ptr<vector_type> build_range_vector() const;
+  virtual std::shared_ptr<vector_type> build_domain_vector() const = 0;
+  virtual std::shared_ptr<vector_type> build_range_vector() const = 0;
 };
 
-template <class Mesh, class GlobalOperatorType,
-          class LocalOperatorType = GlobalOperatorType>
+template <typename Mesh, typename GlobalOperatorType,
+          typename LocalOperatorType = GlobalOperatorType>
 class MeshEvaluator
 {
 public:
@@ -46,32 +52,56 @@ public:
 
 public:
   std::shared_ptr<global_operator_type>
-  get_global_operator(const mesh_type &mesh) const
+  get_global_operator(mesh_type const &) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
+
+    return nullptr;
   }
+
   std::shared_ptr<local_operator_type>
-  get_local_operator(const mesh_type &mesh) const
+  get_local_operator(mesh_type const &) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
+
+    return nullptr;
   }
 };
 
-template <class MeshEvaluatorType>
+template <typename MeshEvaluatorType>
 class Adapter
 {
 public:
   using mesh_type = typename MeshEvaluatorType::mesh_type;
+  using operator_type = typename MeshEvaluatorType::operator_type;
   using global_operator_type = typename MeshEvaluatorType::global_operator_type;
   using mesh_evaluator_type = MeshEvaluatorType;
 
 public:
-  std::shared_ptr<global_operator_type> build_restrictor(
-      MPI_Comm comm, const mesh_evaluator_type &evaluator,
-      const mesh_type &mesh,
-      std::shared_ptr<const boost::property_tree::ptree> params) const
+  static std::shared_ptr<operator_type>
+  build_restrictor(MPI_Comm, mesh_evaluator_type const &, mesh_type const &,
+                   std::shared_ptr<boost::property_tree::ptree const>)
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
+
+    return nullptr;
+  }
+
+  static std::shared_ptr<operator_type>
+  build_smoother(operator_type const &,
+                 std::shared_ptr<boost::property_tree::ptree>)
+  {
+    ASSERT_THROW_NOT_IMPLEMENTED();
+
+    return nullptr;
+  }
+
+  static std::shared_ptr<operator_type>
+  build_direct_solver(operator_type const &)
+  {
+    ASSERT_THROW_NOT_IMPLEMENTED();
+
+    return nullptr;
   }
 };
 }

--- a/include/mfmg/concepts.hpp
+++ b/include/mfmg/concepts.hpp
@@ -29,16 +29,24 @@ public:
   using operator_type = Operator<VectorType>;
   using vector_type = VectorType;
 
-public:
   virtual size_t m() const = 0;
   virtual size_t n() const = 0;
   virtual void apply(vector_type const &x, vector_type &y) const = 0;
-  virtual std::shared_ptr<operator_type> transpose() const = 0;
-  virtual std::shared_ptr<operator_type>
-  multiply(operator_type const &b) const = 0;
 
   virtual std::shared_ptr<vector_type> build_domain_vector() const = 0;
   virtual std::shared_ptr<vector_type> build_range_vector() const = 0;
+};
+
+template <typename VectorType>
+class MatrixOperator : public Operator<VectorType>
+{
+public:
+  using operator_type = MatrixOperator<VectorType>;
+  using vector_type = VectorType;
+
+  virtual std::shared_ptr<operator_type> transpose() const = 0;
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &b) const = 0;
 };
 
 template <typename Mesh, typename GlobalOperatorType,
@@ -50,7 +58,6 @@ public:
   using local_operator_type = LocalOperatorType;
   using mesh_type = Mesh;
 
-public:
   std::shared_ptr<global_operator_type>
   get_global_operator(mesh_type const &) const
   {
@@ -77,7 +84,6 @@ public:
   using global_operator_type = typename MeshEvaluatorType::global_operator_type;
   using mesh_evaluator_type = MeshEvaluatorType;
 
-public:
   static std::shared_ptr<operator_type>
   build_restrictor(MPI_Comm, mesh_evaluator_type const &, mesh_type const &,
                    std::shared_ptr<boost::property_tree::ptree const>)

--- a/include/mfmg/dealii_adapters.hpp
+++ b/include/mfmg/dealii_adapters.hpp
@@ -42,21 +42,39 @@ struct DealIIMesh
   dealii::ConstraintMatrix &_constraints;
 };
 
-template <int dim, class VectorType>
+template <int dim, typename VectorType>
 class DealIIMeshEvaluator
 {
 public:
   using mesh_type = DealIIMesh<dim>;
   using vector_type = VectorType;
   using value_type = typename VectorType::value_type;
-  using operator_type = DealIIOperator<vector_type>;
+  using operator_type = Operator<vector_type>;
   using global_operator_type =
-      DealIIMatrixOperator<dealii::TrilinosWrappers::SparsityPattern,
-                           dealii::TrilinosWrappers::SparseMatrix, vector_type>;
+      dealii_adapter::TrilinosMatrixOperator<vector_type>;
   using local_operator_type =
-      DealIIMatrixOperator<dealii::SparsityPattern,
-                           dealii::SparseMatrix<value_type>,
-                           dealii::Vector<value_type>>;
+      dealii_adapter::DealIIMatrixOperator<dealii::Vector<value_type>>;
+
+  DealIIMeshEvaluator() = default;
+
+  // FIXME: should really be "const mesh_type& mesh, but right now `evaluate`
+  // actually modifies the `dof_handler` due to `distribute_dofs
+  std::shared_ptr<global_operator_type const>
+  get_global_operator(mesh_type &mesh) const;
+
+  std::shared_ptr<local_operator_type const>
+  get_local_operator(mesh_type &mesh) const;
+
+  // For deal.II, because of the way it deals with hanging nodes and
+  // Dirichlet b.c., we need to zero out the initial guess values
+  // corresponding to those. Otherwise, it may cause issues with spurious
+  // modes and some scaling difficulties. If we use `apply` for deal.II, we
+  // don't need this as we can apply the constraints immediately after
+  // applying the matrix and before any norms and dot products.
+
+  // In addition, this has to work only for ARPACK with dealii::Vector<double>
+  void set_initial_guess(mesh_type const &mesh,
+                         typename local_operator_type::vector_type &x) const;
 
 protected:
   virtual void evaluate(dealii::DoFHandler<dim> &, dealii::ConstraintMatrix &,
@@ -72,70 +90,65 @@ protected:
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
   }
-
-public:
-  DealIIMeshEvaluator() {}
-
-  // FIXME: should really be "const mesh_type& mesh, but right now `evaluate`
-  // actually modifies the `dof_handler` due to `distribute_dofs
-  std::shared_ptr<const global_operator_type>
-  get_global_operator(mesh_type &mesh) const
-  {
-    using matrix_type = typename global_operator_type::matrix_type;
-    using sparsity_pattern_type =
-        typename global_operator_type::sparsity_pattern_type;
-
-    auto system_sparsity_pattern = std::make_shared<sparsity_pattern_type>();
-    auto system_matrix = std::make_shared<matrix_type>();
-
-    // Call user function to fill in the matrix and build the mass matrix
-    evaluate(mesh._dof_handler, mesh._constraints, *system_sparsity_pattern,
-             *system_matrix);
-
-    return std::make_shared<global_operator_type>(system_matrix,
-                                                  system_sparsity_pattern);
-  }
-
-  std::shared_ptr<const local_operator_type>
-  get_local_operator(mesh_type &mesh) const
-  {
-    using matrix_type = typename local_operator_type::matrix_type;
-    using sparsity_pattern_type =
-        typename local_operator_type::sparsity_pattern_type;
-
-    auto system_sparsity_pattern = std::make_shared<sparsity_pattern_type>();
-    auto system_matrix = std::make_shared<matrix_type>();
-
-    // Call user function to fill in the matrix and build the mass matrix
-    evaluate(mesh._dof_handler, mesh._constraints, *system_sparsity_pattern,
-             *system_matrix);
-
-    return std::make_shared<local_operator_type>(system_matrix,
-                                                 system_sparsity_pattern);
-  }
-
-  // For deal.II, because of the way it deals with hanging nodes and
-  // Dirichlet b.c., we need to zero out the initial guess values
-  // corresponding to those. Otherwise, it may cause issues with spurious
-  // modes and some scaling difficulties. If we use `apply` for deal.II, we
-  // don't need this as we can apply the constraints immediately after
-  // applying the matrix and before any norms and dot products.
-
-  // In addition, this has to work only for ARPACK with dealii::Vector<double>
-  void set_initial_guess(const mesh_type &mesh,
-                         typename local_operator_type::vector_type &x) const
-  {
-    unsigned int const n = x.size();
-
-    std::default_random_engine generator;
-    std::uniform_real_distribution<value_type> distribution(0., 1.);
-    for (unsigned int i = 0; i < n; ++i)
-      x[i] = (mesh._constraints.is_constrained(i) == false
-                  ? distribution(generator)
-                  : 0.);
-  }
 };
 
+template <int dim, typename VectorType>
+std::shared_ptr<
+    typename DealIIMeshEvaluator<dim, VectorType>::global_operator_type const>
+DealIIMeshEvaluator<dim, VectorType>::get_global_operator(mesh_type &mesh) const
+{
+  using matrix_type = typename global_operator_type::matrix_type;
+  using sparsity_pattern_type =
+      typename global_operator_type::sparsity_pattern_type;
+
+  auto system_sparsity_pattern = std::make_shared<sparsity_pattern_type>();
+  auto system_matrix = std::make_shared<matrix_type>();
+
+  // Call user function to fill in the matrix and build the mass matrix
+  evaluate(mesh._dof_handler, mesh._constraints, *system_sparsity_pattern,
+           *system_matrix);
+
+  return std::make_shared<global_operator_type>(system_matrix,
+                                                system_sparsity_pattern);
+}
+
+template <int dim, typename VectorType>
+std::shared_ptr<
+    typename DealIIMeshEvaluator<dim, VectorType>::local_operator_type const>
+DealIIMeshEvaluator<dim, VectorType>::get_local_operator(mesh_type &mesh) const
+{
+  using matrix_type = typename local_operator_type::matrix_type;
+  using sparsity_pattern_type =
+      typename local_operator_type::sparsity_pattern_type;
+
+  auto system_sparsity_pattern = std::make_shared<sparsity_pattern_type>();
+  auto system_matrix = std::make_shared<matrix_type>();
+
+  // Call user function to fill in the matrix and build the mass matrix
+  evaluate(mesh._dof_handler, mesh._constraints, *system_sparsity_pattern,
+           *system_matrix);
+
+  return std::make_shared<local_operator_type>(system_matrix,
+                                               system_sparsity_pattern);
+}
+
+template <int dim, typename VectorType>
+void DealIIMeshEvaluator<dim, VectorType>::set_initial_guess(
+    typename DealIIMeshEvaluator<dim, VectorType>::mesh_type const &mesh,
+    typename DealIIMeshEvaluator<
+        dim, VectorType>::local_operator_type::vector_type &x) const
+{
+  unsigned int const n = x.size();
+
+  std::default_random_engine generator;
+  std::uniform_real_distribution<value_type> distribution(0., 1.);
+  for (unsigned int i = 0; i < n; ++i)
+    x[i] =
+        (mesh._constraints.is_constrained(i) == false ? distribution(generator)
+                                                      : 0.);
+}
+
+// This is a specialization of Adapter in concepts.hpp
 template <int dim, class VectorType>
 class Adapter<DealIIMeshEvaluator<dim, VectorType>>
 {
@@ -145,13 +158,13 @@ protected:
   using operator_type = typename mesh_evaluator_type::operator_type;
   using global_operator_type =
       typename mesh_evaluator_type::global_operator_type;
-  using smoother_type = DealIISmootherOperator<VectorType>;
-  using direct_solver_type = DealIIDirectOperator<VectorType>;
+  using smoother_type = dealii_adapter::SmootherOperator<VectorType>;
+  using direct_solver_type = dealii_adapter::DirectOperator<VectorType>;
   using vector_type = typename operator_type::vector_type;
 
 public:
   static std::shared_ptr<operator_type>
-  build_restrictor(MPI_Comm comm, const mesh_evaluator_type &evaluator,
+  build_restrictor(MPI_Comm comm, mesh_evaluator_type const &evaluator,
                    mesh_type &mesh,
                    std::shared_ptr<boost::property_tree::ptree> params)
   {
@@ -177,17 +190,17 @@ public:
   }
 
   static std::shared_ptr<operator_type>
-  build_smoother(const operator_type &op,
+  build_smoother(operator_type const &op,
                  std::shared_ptr<boost::property_tree::ptree> params)
   {
-    auto global_op = dynamic_cast<const global_operator_type &>(op);
+    auto global_op = dynamic_cast<global_operator_type const &>(op);
     return std::make_shared<smoother_type>(*global_op.get_matrix(), params);
   }
 
   static std::shared_ptr<operator_type>
-  build_direct_solver(const operator_type &op)
+  build_direct_solver(operator_type const &op)
   {
-    auto global_op = dynamic_cast<const global_operator_type &>(op);
+    auto global_op = dynamic_cast<global_operator_type const &>(op);
     return std::make_shared<direct_solver_type>(*global_op.get_matrix());
   }
 };

--- a/include/mfmg/dealii_adapters.hpp
+++ b/include/mfmg/dealii_adapters.hpp
@@ -50,10 +50,8 @@ public:
   using vector_type = VectorType;
   using value_type = typename VectorType::value_type;
   using operator_type = Operator<vector_type>;
-  using global_operator_type =
-      dealii_adapter::TrilinosMatrixOperator<vector_type>;
-  using local_operator_type =
-      dealii_adapter::DealIIMatrixOperator<dealii::Vector<value_type>>;
+  using global_operator_type = DealIITrilinosMatrixOperator<vector_type>;
+  using local_operator_type = DealIIMatrixOperator<dealii::Vector<value_type>>;
 
   DealIIMeshEvaluator() = default;
 
@@ -158,8 +156,8 @@ protected:
   using operator_type = typename mesh_evaluator_type::operator_type;
   using global_operator_type =
       typename mesh_evaluator_type::global_operator_type;
-  using smoother_type = dealii_adapter::SmootherOperator<VectorType>;
-  using direct_solver_type = dealii_adapter::DirectOperator<VectorType>;
+  using smoother_type = DealIISmootherOperator<VectorType>;
+  using direct_solver_type = DealIIDirectOperator<VectorType>;
   using vector_type = typename operator_type::vector_type;
 
 public:

--- a/include/mfmg/dealii_adapters.hpp
+++ b/include/mfmg/dealii_adapters.hpp
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#ifndef MFMG_ADAPTERS_DEALII_HPP
-#define MFMG_ADAPTERS_DEALII_HPP
+#ifndef MFMG_DEALII_ADAPTERS_HPP
+#define MFMG_DEALII_ADAPTERS_HPP
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -120,7 +120,7 @@ public:
   // modes and some scaling difficulties. If we use `apply` for deal.II, we
   // don't need this as we can apply the constraints immediately after
   // applying the matrix and before any norms and dot products.
-  //
+
   // In addition, this has to work only for ARPACK with dealii::Vector<double>
   void set_initial_guess(const mesh_type &mesh,
                          typename local_operator_type::vector_type &x) const

--- a/include/mfmg/dealii_operator.hpp
+++ b/include/mfmg/dealii_operator.hpp
@@ -15,8 +15,11 @@
 #include <mfmg/concepts.hpp>
 #include <mfmg/exceptions.hpp>
 
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
 
 #include <EpetraExt_Transpose_RowMatrix.h>
 
@@ -28,133 +31,21 @@
 namespace mfmg
 {
 
-template <class VectorType>
-class DealIIOperator
+namespace dealii_adapter
 {
-public:
-  using vector_type = VectorType;
 
-public:
-  virtual void apply(const vector_type &x, vector_type &y) const = 0;
-
-  virtual size_t m() const = 0;
-  virtual size_t n() const = 0;
-
-  virtual std::shared_ptr<vector_type> build_domain_vector() const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-
-  virtual std::shared_ptr<vector_type> build_range_vector() const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-};
-
-template <class SparsityPatternType, class MatrixType, class VectorType>
-class DealIIMatrixOperator : public DealIIOperator<VectorType>
-{
-public:
-  using sparsity_pattern_type = SparsityPatternType;
-  using matrix_type = MatrixType;
-  using vector_type = VectorType;
-  using operator_type =
-      DealIIMatrixOperator<sparsity_pattern_type, matrix_type, vector_type>;
-
-public:
-  DealIIMatrixOperator(
-      std::shared_ptr<matrix_type> matrix,
-      std::shared_ptr<sparsity_pattern_type> sparsity_pattern = nullptr)
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-  }
-
-  virtual size_t m() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return 0;
-  }
-
-  virtual size_t n() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-    return 0;
-  }
-
-  virtual size_t nnz() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-    return 0;
-  }
-
-  virtual void apply(const vector_type &x, vector_type &y) const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-  }
-
-  std::shared_ptr<operator_type> transpose() const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-
-  std::shared_ptr<operator_type> multiply(const operator_type &operator_b) const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-
-  std::shared_ptr<matrix_type> get_matrix() const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-
-  virtual std::shared_ptr<vector_type>
-  build_domain_vector() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-
-  virtual std::shared_ptr<vector_type> build_range_vector() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
-};
-
-template <class VectorType>
-class DealIIMatrixOperator<
-    dealii::SparsityPattern,
-    dealii::SparseMatrix<typename VectorType::value_type>, VectorType>
-    : public DealIIOperator<VectorType>
+template <typename VectorType>
+class DealIIMatrixOperator : public Operator<VectorType>
 {
 public:
   using value_type = typename VectorType::value_type;
   using sparsity_pattern_type = dealii::SparsityPattern;
   using matrix_type = dealii::SparseMatrix<value_type>;
   using vector_type = VectorType;
-  using operator_type =
-      DealIIMatrixOperator<sparsity_pattern_type, matrix_type, vector_type>;
+  using operator_type = Operator<vector_type>;
 
-public:
-  DealIIMatrixOperator(
-      std::shared_ptr<matrix_type> matrix,
-      std::shared_ptr<sparsity_pattern_type> sparsity_pattern = nullptr)
-      : _sparsity_pattern(sparsity_pattern), _matrix(matrix)
-  {
-  }
+  DealIIMatrixOperator(std::shared_ptr<matrix_type> matrix,
+                       std::shared_ptr<sparsity_pattern_type> sparsity_pattern);
 
   virtual size_t m() const override final { return _matrix->m(); }
 
@@ -162,72 +53,43 @@ public:
 
   size_t nnz() const { return _matrix->n_nonzero_elements(); }
 
-  virtual void apply(const vector_type &x, vector_type &y) const override final
-  {
-    _matrix->vmult(y, x);
-  }
+  virtual void apply(vector_type const &x, vector_type &y) const override final;
 
-  std::shared_ptr<operator_type> transpose() const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
+  virtual std::shared_ptr<operator_type> transpose() const override final;
 
-    return nullptr;
-  }
-
-  std::shared_ptr<operator_type> multiply(const operator_type &operator_b) const
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &operator_b) const override final;
 
   std::shared_ptr<matrix_type> get_matrix() const { return _matrix; }
 
   virtual std::shared_ptr<vector_type>
-  build_domain_vector() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
+  build_domain_vector() const override final;
 
-    return nullptr;
-  }
-
-  virtual std::shared_ptr<vector_type> build_range_vector() const override final
-  {
-    ASSERT_THROW_NOT_IMPLEMENTED();
-
-    return nullptr;
-  }
+  virtual std::shared_ptr<vector_type>
+  build_range_vector() const override final;
 
 private:
-  // TODO: for some reason, order here is important. If _sparsity_pattern after
-  // _matrix, it results in some dealii subscriptor throws.
-  std::shared_ptr<sparsity_pattern_type>
-      _sparsity_pattern; // this may only be necessary for dealii::SparseMatrix,
-                         // which does not store the pattern. For Trilinos
-                         // matrices, this is not needed.
+  // The sparsity pattern needs to outlive the sparse matrix, so we declare it
+  // first. This is only necessary for dealii for deal.II sparse matrix.
+  // Trilinos saves the Epetra_Map inside the sparse matrix.
+  std::shared_ptr<sparsity_pattern_type> _sparsity_pattern;
+
   std::shared_ptr<matrix_type> _matrix;
 };
 
-template <class VectorType>
-class DealIIMatrixOperator<dealii::TrilinosWrappers::SparsityPattern,
-                           dealii::TrilinosWrappers::SparseMatrix, VectorType>
-    : public DealIIOperator<VectorType>
+template <typename VectorType>
+class TrilinosMatrixOperator : public Operator<VectorType>
 {
 public:
   using value_type = typename VectorType::value_type;
   using sparsity_pattern_type = dealii::TrilinosWrappers::SparsityPattern;
   using matrix_type = dealii::TrilinosWrappers::SparseMatrix;
   using vector_type = VectorType;
-  using operator_type =
-      DealIIMatrixOperator<sparsity_pattern_type, matrix_type, vector_type>;
+  using operator_type = Operator<vector_type>;
 
-public:
-  DealIIMatrixOperator(
+  TrilinosMatrixOperator(
       std::shared_ptr<matrix_type> matrix,
-      std::shared_ptr<sparsity_pattern_type> sparsity_pattern = nullptr)
-      : _sparsity_pattern(sparsity_pattern), _matrix(matrix)
-  {
-  }
+      std::shared_ptr<sparsity_pattern_type> sparsity_pattern = nullptr);
 
   virtual size_t m() const override final { return _matrix->m(); }
 
@@ -235,206 +97,95 @@ public:
 
   size_t nnz() const { return _matrix->n_nonzero_elements(); }
 
-  virtual void apply(const vector_type &x, vector_type &y) const override final
-  {
-    _matrix->vmult(y, x);
-  }
+  virtual void apply(vector_type const &x, vector_type &y) const override final;
 
-  std::shared_ptr<operator_type> transpose() const
-  {
-    auto epetra_matrix = _matrix->trilinos_matrix();
+  virtual std::shared_ptr<operator_type> transpose() const override final;
 
-    EpetraExt::RowMatrix_Transpose transposer;
-    auto transposed_epetra_matrix =
-        dynamic_cast<Epetra_CrsMatrix &>(transposer(epetra_matrix));
-
-    auto transposed_matrix = std::make_shared<matrix_type>();
-    transposed_matrix->reinit(transposed_epetra_matrix);
-
-    return std::make_shared<operator_type>(transposed_matrix);
-  }
-
-  std::shared_ptr<operator_type> multiply(const operator_type &operator_b) const
-  {
-    auto a = this->get_matrix();
-    auto b = operator_b.get_matrix();
-
-    auto c = std::make_shared<matrix_type>();
-    a->mmult(*c, *b);
-
-    return std::make_shared<operator_type>(c);
-  }
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &operator_b) const override final;
 
   std::shared_ptr<matrix_type> get_matrix() const { return _matrix; }
 
   virtual std::shared_ptr<vector_type>
-  build_domain_vector() const override final
-  {
-    return std::make_shared<vector_type>(
-        _matrix->locally_owned_domain_indices(),
-        _matrix->get_mpi_communicator());
-  }
+  build_domain_vector() const override final;
 
-  std::shared_ptr<vector_type> build_range_vector() const override final
-  {
-    return std::make_shared<vector_type>(_matrix->locally_owned_range_indices(),
-                                         _matrix->get_mpi_communicator());
-  }
+  std::shared_ptr<vector_type> build_range_vector() const override final;
 
 private:
-  // TODO: for some reason, order here is important. If _sparsity_pattern after
-  // _matrix, it results in some dealii subscriptor throws.
-  std::shared_ptr<sparsity_pattern_type>
-      _sparsity_pattern; // this may only be necessary for dealii::SparseMatrix,
-                         // which does not store the pattern. For Trilinos
-                         // matrices, this is not needed.
   std::shared_ptr<matrix_type> _matrix;
 };
 
-template <class VectorType>
-class DealIISmootherOperator : public DealIIOperator<VectorType>
+template <typename VectorType>
+class SmootherOperator : public Operator<VectorType>
 {
 public:
   using vector_type = VectorType;
   using matrix_type = dealii::TrilinosWrappers::SparseMatrix;
+  using operator_type = Operator<vector_type>;
 
-private:
-  enum SmootherType
-  {
-    SGS,
-    GS,
-    JACOBI,
-    ILU
-  };
-
-public:
-  DealIISmootherOperator(const matrix_type &matrix,
-                         std::shared_ptr<boost::property_tree::ptree> params)
-      : _matrix(matrix)
-  {
-    std::string prec_name = params->get<std::string>("preconditioner: type",
-                                                     "Symmetric Gauss-Seidel");
-    _prec_type = string2type(prec_name);
-    initialize(_prec_type);
-  }
+  SmootherOperator(matrix_type const &matrix,
+                   std::shared_ptr<boost::property_tree::ptree> params);
 
   virtual size_t m() const override final { return _matrix.m(); }
 
   virtual size_t n() const override final { return _matrix.n(); }
 
-  void apply(const vector_type &b, vector_type &x) const
-  {
-    // r = -(b - Ax)
-    vector_type r(b);
-    _matrix.vmult(r, x);
-    r.add(-1., b);
+  virtual void apply(vector_type const &b, vector_type &x) const override final;
 
-    // x = x + B^{-1} (-r)
-    vector_type tmp(x);
-    smoother_vmult(tmp, r);
-    x.add(-1., tmp);
-  }
+  virtual std::shared_ptr<operator_type> transpose() const override final;
 
-private:
-  SmootherType string2type(const std::string &prec_name) const
-  {
-    // Make parameters case-insensitive
-    std::string prec_name_lower = prec_name;
-    std::transform(prec_name_lower.begin(), prec_name_lower.end(),
-                   prec_name_lower.begin(), ::tolower);
-    if (prec_name_lower == "symmetric gauss-seidel")
-      return SGS;
-    else if (prec_name_lower == "gauss-seidel")
-      return GS;
-    else if (prec_name_lower == "jacobi")
-      return JACOBI;
-    else if (prec_name_lower == "ilu")
-      return ILU;
-    else
-      throw std::runtime_error("Unknown smoother name: \"" + prec_name_lower +
-                               "\"");
-  }
-  void initialize(const SmootherType prec_type)
-  {
-    switch (prec_type)
-    {
-    case SGS:
-      _sgs_smoother.initialize(_matrix);
-      break;
-    case GS:
-      _gs_smoother.initialize(_matrix);
-      break;
-    case JACOBI:
-      _jacobi_smoother.initialize(_matrix);
-      break;
-    case ILU:
-      _ilu_smoother.initialize(_matrix);
-      break;
-    };
-  }
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &operator_b) const override final;
 
-  void smoother_vmult(vector_type &x, const vector_type &b) const
-  {
-    {
-      switch (_prec_type)
-      {
-      case SGS:
-        _sgs_smoother.vmult(x, b);
-        break;
-      case GS:
-        _gs_smoother.vmult(x, b);
-        break;
-      case JACOBI:
-        _jacobi_smoother.vmult(x, b);
-        break;
-      case ILU:
-        _ilu_smoother.vmult(x, b);
-        break;
-      };
-    }
-  }
+  virtual std::shared_ptr<VectorType>
+  build_domain_vector() const override final;
+
+  virtual std::shared_ptr<VectorType> build_range_vector() const override final;
 
 private:
-  const matrix_type &_matrix;
-  SmootherType _prec_type;
-  dealii::TrilinosWrappers::PreconditionSSOR _sgs_smoother;
-  dealii::TrilinosWrappers::PreconditionSOR _gs_smoother;
-  dealii::TrilinosWrappers::PreconditionJacobi _jacobi_smoother;
-  dealii::TrilinosWrappers::PreconditionILU _ilu_smoother;
+  void initialize(std::string const &prec_type);
+
+  matrix_type const &_matrix;
+  std::unique_ptr<dealii::TrilinosWrappers::PreconditionBase> _smoother;
 };
 
-template <class VectorType>
-class DealIIDirectOperator : public DealIIOperator<VectorType>
+template <typename VectorType>
+class DirectOperator : public Operator<VectorType>
 {
 public:
   using vector_type = VectorType;
   using matrix_type = dealii::TrilinosWrappers::SparseMatrix;
   using solver_type = dealii::TrilinosWrappers::SolverDirect;
+  using operator_type = Operator<vector_type>;
 
-public:
-  DealIIDirectOperator(const matrix_type &a)
-  {
-    _solver = std::make_shared<solver_type>(_solver_control);
-    _solver->initialize(a);
-    _m = a.m();
-    _n = a.n();
-  }
+  DirectOperator(matrix_type const &matrix);
 
   virtual size_t m() const override final { return _m; }
 
   virtual size_t n() const override final { return _n; }
 
-  void apply(const vector_type &b, vector_type &x) const
+  virtual void apply(vector_type const &b, vector_type &x) const override final
   {
     _solver->solve(x, b);
   }
 
+  virtual std::shared_ptr<operator_type> transpose() const override final;
+
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &operator_b) const override final;
+
+  virtual std::shared_ptr<VectorType>
+  build_domain_vector() const override final;
+
+  virtual std::shared_ptr<VectorType> build_range_vector() const override final;
+
 private:
   dealii::SolverControl _solver_control;
-  std::shared_ptr<dealii::TrilinosWrappers::SolverDirect> _solver;
+  std::unique_ptr<dealii::TrilinosWrappers::SolverDirect> _solver;
   size_t _m;
   size_t _n;
 };
+}
 }
 
 #endif

--- a/include/mfmg/dealii_operator.templates.hpp
+++ b/include/mfmg/dealii_operator.templates.hpp
@@ -1,0 +1,296 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_OPERATOR_TEMPLATES_HPP
+#define MFMG_DEALII_OPERATOR_TEMPLATES_HPP
+
+#include <mfmg/dealii_operator.hpp>
+
+namespace mfmg
+{
+namespace dealii_adapter
+{
+
+template <typename VectorType>
+DealIIMatrixOperator<VectorType>::DealIIMatrixOperator(
+    std::shared_ptr<typename DealIIMatrixOperator<VectorType>::matrix_type>
+        matrix,
+    std::shared_ptr<dealii::SparsityPattern> sparsity_pattern)
+    : _sparsity_pattern(sparsity_pattern), _matrix(matrix)
+{
+  ASSERT(sparsity_pattern != nullptr,
+         "deal.II matrices require a sparsity pattern");
+
+  ASSERT(matrix != nullptr, "The matrix must exist");
+}
+
+template <typename VectorType>
+void DealIIMatrixOperator<VectorType>::apply(VectorType const &x,
+                                             VectorType &y) const
+{
+  _matrix->vmult(y, x);
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DealIIMatrixOperator<VectorType>::transpose() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DealIIMatrixOperator<VectorType>::multiply(
+    Operator<VectorType> const &operator_b) const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DealIIMatrixOperator<VectorType>::build_domain_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DealIIMatrixOperator<VectorType>::build_range_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+//-------------------------------------------------------------------------//
+
+template <typename VectorType>
+TrilinosMatrixOperator<VectorType>::TrilinosMatrixOperator(
+    std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> matrix,
+    std::shared_ptr<dealii::TrilinosWrappers::SparsityPattern>)
+    : _matrix(matrix)
+{
+}
+
+template <typename VectorType>
+void TrilinosMatrixOperator<VectorType>::apply(VectorType const &x,
+                                               vector_type &y) const
+{
+  _matrix->vmult(y, x);
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+TrilinosMatrixOperator<VectorType>::transpose() const
+{
+  auto epetra_matrix = _matrix->trilinos_matrix();
+
+  EpetraExt::RowMatrix_Transpose transposer;
+  auto transposed_epetra_matrix =
+      dynamic_cast<Epetra_CrsMatrix &>(transposer(epetra_matrix));
+
+  auto transposed_matrix = std::make_shared<matrix_type>();
+  transposed_matrix->reinit(transposed_epetra_matrix);
+
+  return std::make_shared<TrilinosMatrixOperator<VectorType>>(
+      transposed_matrix);
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+TrilinosMatrixOperator<VectorType>::multiply(
+    Operator<VectorType> const &operator_b) const
+{
+  // Downcast to TrilinosMatrixOperator
+  auto downcast_operator_b =
+      static_cast<TrilinosMatrixOperator<VectorType> const &>(operator_b);
+
+  auto a = this->get_matrix();
+  auto b = downcast_operator_b.get_matrix();
+
+  auto c = std::make_shared<matrix_type>();
+  a->mmult(*c, *b);
+
+  return std::make_shared<TrilinosMatrixOperator<VectorType>>(c);
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+TrilinosMatrixOperator<VectorType>::build_domain_vector() const
+{
+  return std::make_shared<vector_type>(_matrix->locally_owned_domain_indices(),
+                                       _matrix->get_mpi_communicator());
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+TrilinosMatrixOperator<VectorType>::build_range_vector() const
+{
+  return std::make_shared<vector_type>(_matrix->locally_owned_range_indices(),
+                                       _matrix->get_mpi_communicator());
+}
+
+//-------------------------------------------------------------------------//
+
+template <typename VectorType>
+SmootherOperator<VectorType>::SmootherOperator(
+    dealii::TrilinosWrappers::SparseMatrix const &matrix,
+    std::shared_ptr<boost::property_tree::ptree> params)
+    : _matrix(matrix)
+{
+  std::string prec_type = params->get<std::string>("preconditioner: type",
+                                                   "Symmetric Gauss-Seidel");
+  initialize(prec_type);
+}
+
+template <typename VectorType>
+void SmootherOperator<VectorType>::apply(VectorType const &b,
+                                         VectorType &x) const
+{
+  // r = -(b - Ax)
+  vector_type r(b);
+  _matrix.vmult(r, x);
+  r.add(-1., b);
+
+  // x = x + B^{-1} (-r)
+  vector_type tmp(x);
+  _smoother->vmult(tmp, r);
+  x.add(-1., tmp);
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+SmootherOperator<VectorType>::transpose() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+SmootherOperator<VectorType>::multiply(Operator<VectorType> const &) const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+SmootherOperator<VectorType>::build_domain_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+SmootherOperator<VectorType>::build_range_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+void SmootherOperator<VectorType>::initialize(std::string const &prec_name)
+{
+  // Make parameters case-insensitive
+  std::string prec_name_lower = prec_name;
+  std::transform(prec_name_lower.begin(), prec_name_lower.end(),
+                 prec_name_lower.begin(), ::tolower);
+  if (prec_name_lower == "symmetric gauss-seidel")
+  {
+    _smoother.reset(new dealii::TrilinosWrappers::PreconditionSSOR());
+    static_cast<dealii::TrilinosWrappers::PreconditionSSOR *>(_smoother.get())
+        ->initialize(_matrix);
+  }
+  else if (prec_name_lower == "gauss-seidel")
+  {
+    _smoother.reset(new dealii::TrilinosWrappers::PreconditionSOR());
+    static_cast<dealii::TrilinosWrappers::PreconditionSOR *>(_smoother.get())
+        ->initialize(_matrix);
+  }
+  else if (prec_name_lower == "jacobi")
+  {
+    _smoother.reset(new dealii::TrilinosWrappers::PreconditionJacobi());
+    static_cast<dealii::TrilinosWrappers::PreconditionJacobi *>(_smoother.get())
+        ->initialize(_matrix);
+  }
+  else if (prec_name_lower == "ilu")
+  {
+    _smoother.reset(new dealii::TrilinosWrappers::PreconditionILU());
+    static_cast<dealii::TrilinosWrappers::PreconditionILU *>(_smoother.get())
+        ->initialize(_matrix);
+  }
+  else
+    ASSERT_THROW(false, "Unknown smoother name: \"" + prec_name_lower + "\"");
+}
+
+//-------------------------------------------------------------------------//
+
+template <typename VectorType>
+DirectOperator<VectorType>::DirectOperator(
+    dealii::TrilinosWrappers::SparseMatrix const &matrix)
+{
+  _solver.reset(new solver_type(_solver_control));
+  _solver->initialize(matrix);
+  _m = matrix.m();
+  _n = matrix.n();
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DirectOperator<VectorType>::transpose() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<Operator<VectorType>> DirectOperator<VectorType>::multiply(
+    Operator<VectorType> const &operator_b) const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DirectOperator<VectorType>::build_domain_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DirectOperator<VectorType>::build_range_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+}
+}
+
+#endif

--- a/include/mfmg/dealii_operator.templates.hpp
+++ b/include/mfmg/dealii_operator.templates.hpp
@@ -48,7 +48,7 @@ DealIIMatrixOperator<VectorType>::transpose() const
 template <typename VectorType>
 std::shared_ptr<MatrixOperator<VectorType>>
 DealIIMatrixOperator<VectorType>::multiply(
-    MatrixOperator<VectorType> const &operator_b) const
+    MatrixOperator<VectorType> const &) const
 {
   ASSERT_THROW_NOT_IMPLEMENTED();
 

--- a/include/mfmg/instantiation.hpp
+++ b/include/mfmg/instantiation.hpp
@@ -31,15 +31,43 @@
 #define VECTOR_TYPE                                                            \
   (dealii::TrilinosWrappers::MPI::Vector)(                                     \
       dealii::LinearAlgebra::distributed::Vector<double>)
+#define SERIAL_VECTOR_TYPE (dealii::Vector<double>)
 
-// Instantiation of the class for every dim
+//////////////////////////////////////////////
+// Instantiation of the class for every dim //
+//////////////////////////////////////////////
+
 #define M_DIM_INSTANT(z, dim, CLASS_NAME_TUPLE)                                \
   template class mfmg::BOOST_PP_TUPLE_ELEM(0, CLASS_NAME_TUPLE)<dim>;
 // CLASS_NAME_TUPLE (class_name, 0)
 #define INSTANTIATE_DIM(CLASS_NAME_TUPLE)                                      \
   BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_INSTANT, CLASS_NAME_TUPLE)
 
-// Instantiation of the class for every dim-ScalarType combination
+/////////////////////////////////////////////////////
+// Instantiation of the class for every VectorType //
+/////////////////////////////////////////////////////
+
+#define M_VECTORTYPE_INSTANT(z, CLASS_NAME_TUPLE, vector_type)                 \
+  template class mfmg::BOOST_PP_TUPLE_ELEM(0, CLASS_NAME_TUPLE)<vector_type>;
+// CLASS_NAME_TUPLE (class_name, 0)
+#define INSTANTIATE_VECTORTYPE(CLASS_NAME_TUPLE)                               \
+  BOOST_PP_SEQ_FOR_EACH(M_VECTORTYPE_INSTANT, CLASS_NAME_TUPLE, VECTOR_TYPE)
+
+///////////////////////////////////////////////////////////
+// Instantiation of the class for every SerialVectorType //
+///////////////////////////////////////////////////////////
+
+#define M_SERIALVECTORTYPE_INSTANT(z, CLASS_NAME_TUPLE, vector_type)           \
+  template class mfmg::BOOST_PP_TUPLE_ELEM(0, CLASS_NAME_TUPLE)<vector_type>;
+// CLASS_NAME_TUPLE (class_name, 0)
+#define INSTANTIATE_SERIALVECTORTYPE(CLASS_NAME_TUPLE)                         \
+  BOOST_PP_SEQ_FOR_EACH(M_SERIALVECTORTYPE_INSTANT, CLASS_NAME_TUPLE,          \
+                        SERIAL_VECTOR_TYPE)
+
+/////////////////////////////////////////////////////////////////////
+// Instantiation of the class for every dim-ScalarType combination //
+/////////////////////////////////////////////////////////////////////
+
 #define M_DIM_SCALARTYPE_INSTANT(z, CLASS_NAME_DIM_TUPLE, scalar_type)         \
   template class mfmg::BOOST_PP_TUPLE_ELEM(                                    \
       0, CLASS_NAME_DIM_TUPLE)<BOOST_PP_TUPLE_ELEM(1, CLASS_NAME_DIM_TUPLE),   \
@@ -52,6 +80,10 @@
 // CLASS_NAME_TUPLE (class_name, 0)
 #define INSTANTIATE_DIM_SCALARTYPE(CLASS_NAME_TUPLE)                           \
   BOOST_PP_REPEAT_FROM_TO(2, 4, M_SCALARTYPE, CLASS_NAME_TUPLE)
+
+/////////////////////////////////////////////////////////////////////
+// Instantiation of the class for every dim-VectorType combination //
+/////////////////////////////////////////////////////////////////////
 
 // Because BOOST_PP_COMMA expands to comma only when followed by () and that we
 // cannot expand the macro inside BOOST_PP_IF we need to split the instantiation

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(MFMG_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/amge.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/amge_host.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.cc
   )
 

--- a/source/amge_host.cc
+++ b/source/amge_host.cc
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/adapters_dealii.hpp>
 #include <mfmg/amge_host.templates.hpp>
 #include <mfmg/instantiation.hpp>
 

--- a/source/dealii_operator.cc
+++ b/source/dealii_operator.cc
@@ -12,7 +12,7 @@
 #include <mfmg/dealii_operator.templates.hpp>
 #include <mfmg/instantiation.hpp>
 
-INSTANTIATE_SERIALVECTORTYPE(TUPLE(dealii_adapter::DealIIMatrixOperator))
-INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::TrilinosMatrixOperator))
-INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::SmootherOperator))
-INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::DirectOperator))
+INSTANTIATE_SERIALVECTORTYPE(TUPLE(DealIIMatrixOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(DealIITrilinosMatrixOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(DealIISmootherOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(DealIIDirectOperator))

--- a/source/dealii_operator.cc
+++ b/source/dealii_operator.cc
@@ -1,0 +1,18 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/dealii_operator.templates.hpp>
+#include <mfmg/instantiation.hpp>
+
+INSTANTIATE_SERIALVECTORTYPE(TUPLE(dealii_adapter::DealIIMatrixOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::TrilinosMatrixOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::SmootherOperator))
+INSTANTIATE_VECTORTYPE(TUPLE(dealii_adapter::DirectOperator))

--- a/tests/test_agglomerate.cc
+++ b/tests/test_agglomerate.cc
@@ -13,8 +13,8 @@
 
 #include "main.cc"
 
-#include <mfmg/adapters_dealii.hpp>
 #include <mfmg/amge_host.hpp>
+#include <mfmg/dealii_adapters.hpp>
 
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_accessor.h>

--- a/tests/test_eigenvectors.cc
+++ b/tests/test_eigenvectors.cc
@@ -13,8 +13,8 @@
 
 #include "main.cc"
 
-#include <mfmg/adapters_dealii.hpp>
 #include <mfmg/amge_host.hpp>
+#include <mfmg/dealii_adapters.hpp>
 
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_accessor.h>

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -15,7 +15,7 @@
 
 #include "laplace.hpp"
 
-#include <mfmg/adapters_dealii.hpp>
+#include <mfmg/dealii_adapters.hpp>
 #include <mfmg/hierarchy.hpp>
 
 #include <deal.II/base/conditional_ostream.h>

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -198,15 +198,11 @@ protected:
       fe_values.reinit(cell);
 
       for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
-      {
-        double const diffusion_coefficient =
-            _material_property->value(fe_values.quadrature_point(q_point));
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             cell_matrix(i, j) += fe_values.shape_grad(i, q_point) *
                                  fe_values.shape_grad(j, q_point) *
                                  fe_values.JxW(q_point);
-      }
 
       cell->get_dof_indices(local_dof_indices);
       constraints.distribute_local_to_global(cell_matrix, local_dof_indices,
@@ -255,8 +251,6 @@ double test(std::shared_ptr<boost::property_tree::ptree> params)
   auto const locally_owned_dofs = laplace._locally_owned_dofs;
   DVector solution(locally_owned_dofs, comm);
   DVector rhs(laplace._system_rhs);
-
-  const int local_size = rhs.local_size();
 
   std::default_random_engine generator;
   std::uniform_real_distribution<typename DVector::value_type> distribution(0.,

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -15,8 +15,8 @@
 
 #include "laplace.hpp"
 
-#include <mfmg/adapters_dealii.hpp>
 #include <mfmg/amge_host.hpp>
+#include <mfmg/dealii_adapters.hpp>
 
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/distributed/tria.h>


### PR DESCRIPTION
The first two commits relates to #37 and are mostly cosmetic. The third commit is more interesting. I have talked with @dalg24 and we thought that the current design was too complicated. This PR removes `DealIIOperator` (which was missing some functions and therefore was not an `Operator` as defined in `concept.hpp`) and it also removes `DealIIMatrixOperator`. Instead of specializing `DealIIMatrixOperator`, we now have classes that derived directly from `Operator`. The classes are `DealIIMatrixOperator` for the `dealii::SparseMatrix` and `TrilinosMatrixOperator` for the `dealii::TrilinosWrappers::SparseMatrix`. This classes are in the `dealii_adapter` namespace and should probably be moved in a `dealii` subdirectory later. The new structure is simpler and allows us to use ETI.