### PR TITLE
Improve ReadTheDocs documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,6 +12,7 @@ Welcome to mfmg's documentation!
 
 
    overview
+   install
 
 Indices and tables
 ==================

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,0 +1,57 @@
+Installation
+============
+
+This section provide guidelines for installing DataTransferKit and its TPLs.
+
+Install third-party libraries
+-----------------------------
+
+The following third party libraries (TPLs) are used by mfmg:
+
++------------------------+---------+
+| Packages               | Version |
++========================+=========+
+| ARPACK                 | N/A     |
++------------------------+---------+
+| Boost                  | 1.65.1  |
++------------------------+---------+
+| BLAS/LAPACK            | N/A     |
++------------------------+---------+
+| deal.II                | 8.5     |
++------------------------+---------+
+| MPI                    | N/A     |
++------------------------+---------+
+| Trilinos               | 12.X    |
++------------------------+---------+
+
+The dependencies of mfmg may be built using `Spack
+<https://github.com/llnl/spack>`_ package manager. You need to install the
+following package:
+
+.. code::
+
+    $ spack install dealii
+
+This will install all the dependencies of mfmg.
+
+Building mfmg
+-------------
+
+Create a ``do-configure`` script such as:
+
+.. code-block:: bash
+
+    cmake \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D MFMG_ENABLE_TESTS=ON \
+        -D MFMG_ENABLE_CUDA=ON \
+        -D CMAKE_CUDA_FLAGS="-arch=sm_35" \
+        -D DEAL_II_DIR=${DEAL_II_DIR}
+        ..
+
+and run it from your build directory:
+
+.. code::
+
+    $ mkdir build && cd build
+    $ ../do-configure

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -3,4 +3,29 @@ Getting started with mfmg
 
 Overview
 --------
-`mfmg <https://github.com/ORNL-CEES/mfmg>`_ is an open-source software library.
+`mfmg <https://github.com/ORNL-CEES/mfmg>`_ is an open-source software library
+for matrix-free multigrid.
+
+mfmg is supported by the following programs:
+
+* Oak Ridge National Laboratory (ORNL) Laboratory Directed Research and
+  Development (`LDRD
+  <https://www.ornl.gov/content/laboratory-directed-research-development>`_)
+
+mfmg Development Team
+---------------------
+
+mfmg is developed and maintained by:
+
+* `Bruno Turcksin <turcksinbr@ornl.gov>`_
+
+* `Andrey Prokopenko <prokopenkoav@ornl.gov>`_
+
+* `Wayne Joubert <joubert@ornl.gov>`_
+
+Questions, Bug Reporting, and Issue Tracking
+--------------------------------------------
+
+Questions, bug reporting and issue tracking are provided by GitHub. Please
+report all bugs by creating a new issue. You can ask questions by creating a
+new issue with the question tag.


### PR DESCRIPTION
Not a very interesting patch but we can't put on the report that we use `ReadTheDocs` if there is no useful information on the website.