### PR TITLE
Reduce tolerance when testing the hierarchy on hyper_ball

### DIFF
--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -356,7 +356,8 @@ BOOST_DATA_TEST_CASE(hierarchy_3d,
       // TODO investigate why on the hyper_ball the error is larger on the
       // testing machine
       BOOST_TEST(
-          conv_rate <
-          2 * ref_solution[std::make_tuple(mesh, distort_random, reordering)]);
+          conv_rate ==
+              ref_solution[std::make_tuple(mesh, distort_random, reordering)],
+          tt::tolerance(1e-6));
   }
 }


### PR DESCRIPTION
Close #40 The bad convergence disappears when updating the Docker image to the latest deal.II version. There was some work in deal.II to improve the `hyper_ball` mesh, so this is probably what I saw.