### PR TITLE
Use child property tree

### DIFF
--- a/include/mfmg/dealii_adapters.hpp
+++ b/include/mfmg/dealii_adapters.hpp
@@ -166,17 +166,18 @@ public:
                    mesh_type &mesh,
                    std::shared_ptr<boost::property_tree::ptree> params)
   {
+    auto eigensolver_params = params->get_child("eigensolver");
     AMGe_host<mesh_type::dimension(), mesh_evaluator_type, vector_type> amge(
-        comm, mesh._dof_handler, params->get("eigensolver: type", "arpack"));
+        comm, mesh._dof_handler, eigensolver_params.get("type", "arpack"));
 
     std::array<unsigned int, dim> agglomerate_dim;
-    agglomerate_dim[0] = params->get<unsigned int>("agglomeration: nx");
-    agglomerate_dim[1] = params->get<unsigned int>("agglomeration: ny");
+    auto agglomerate_params = params->get_child("agglomeration");
+    agglomerate_dim[0] = agglomerate_params.get<unsigned int>("nx");
+    agglomerate_dim[1] = agglomerate_params.get<unsigned int>("ny");
     if (dim == 3)
-      agglomerate_dim[2] = params->get<unsigned int>("agglomeration: nz");
-    int n_eigenvectors =
-        params->get<int>("eigensolver: number of eigenvectors", 1);
-    double tolerance = params->get<double>("eigensolver: tolerance", 1e-14);
+      agglomerate_dim[2] = agglomerate_params.get<unsigned int>("nz");
+    int n_eigenvectors = eigensolver_params.get("number of eigenvectors", 1);
+    double tolerance = eigensolver_params.get("tolerance", 1e-14);
 
     auto restrictor_matrix =
         std::make_shared<typename global_operator_type::matrix_type>();

--- a/include/mfmg/dealii_operator.templates.hpp
+++ b/include/mfmg/dealii_operator.templates.hpp
@@ -149,8 +149,8 @@ DealIISmootherOperator<VectorType>::DealIISmootherOperator(
     std::shared_ptr<boost::property_tree::ptree> params)
     : _matrix(matrix)
 {
-  std::string prec_type = params->get<std::string>("preconditioner: type",
-                                                   "Symmetric Gauss-Seidel");
+  std::string prec_type =
+      params->get("smoother.type", "Symmetric Gauss-Seidel");
   initialize(prec_type);
 }
 

--- a/tests/data/hierarchy_input.info
+++ b/tests/data/hierarchy_input.info
@@ -1,9 +1,21 @@
-"eigensolver: number of eigenvectors" 2
-"eigensolver: tolerance" 1e-14
-"preconditioner: type" "Gauss-Seidel"
+eigensolver
+{
+  "number of eigenvectors" 2
+  tolerance 1e-14
+}
+
+smoother
+{
+  type  "Gauss-Seidel"
+}
+
 "is preconditioner" false
-"agglomeration: nx" 2
-"agglomeration: ny" 2
+
+agglomeration
+{
+  nx 2
+  ny 2
+}
 
 material_property
 {

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -322,8 +322,8 @@ BOOST_DATA_TEST_CASE(hierarchy_3d,
     boost::property_tree::info_parser::read_info("hierarchy_input.info",
                                                  *params);
 
-    params->put("eigensolver: type", "lapack");
-    params->put("agglomeration: nz", 2);
+    params->put("eigensolver.type", "lapack");
+    params->put("agglomeration.nz", 2);
     params->put("laplace.n_refinements", 2);
     params->put("laplace.mesh", mesh);
     params->put("laplace.distort_random", distort_random);

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -254,13 +254,13 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-14))
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
-  params->put("eigensolver: number of eigenvectors", 1);
+  params->put("eigensolver.number of eigenvectors", 1);
   std::array<unsigned int, dim> agglomerate_dim;
-  agglomerate_dim[0] = params->get<unsigned int>("agglomeration: nx");
-  agglomerate_dim[1] = params->get<unsigned int>("agglomeration: ny");
+  agglomerate_dim[0] = params->get<unsigned int>("agglomeration.nx");
+  agglomerate_dim[1] = params->get<unsigned int>("agglomeration.ny");
   int n_eigenvectors =
-      params->get<int>("eigensolver: number of eigenvectors", 1);
-  double tolerance = params->get<double>("eigensolver: tolerance", 1e-14);
+      params->get<int>("eigensolver.number of eigenvectors", 1);
+  double tolerance = params->get<double>("eigensolver.tolerance", 1e-14);
 
   params->put("laplace.n_refinements", 4);
   std::shared_ptr<dealii::Function<dim>> material_property =


### PR DESCRIPTION
Use child property tree to group input parameters.

Relates to #37 