### PR TITLE
Add direct solvers

### DIFF
--- a/include/mfmg/dealii_operator_device.cuh
+++ b/include/mfmg/dealii_operator_device.cuh
@@ -1,0 +1,64 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_OPERATOR_DEVICE_CUH
+#define MFMG_DEALII_OPERATOR_DEVICE_CUH
+
+#ifdef MFMG_WITH_CUDA
+
+#include <mfmg/concepts.hpp>
+#include <mfmg/exceptions.hpp>
+#include <mfmg/sparse_matrix_device.cuh>
+
+#include <cusolverDn.h>
+#include <cusolverSp.h>
+
+namespace mfmg
+{
+template <typename VectorType>
+class DirectDeviceOperator : public Operator<VectorType>
+{
+public:
+  using value_type = typename VectorType::value_type;
+  using vector_type = VectorType;
+  using matrix_type = SparseMatrixDevice<value_type>;
+  using operator_type = Operator<vector_type>;
+
+  // Need to move the matrix to only one gpu -> need gather/scatter
+  DirectDeviceOperator(cusolverDnHandle_t cusolver_dn_handle,
+                       cusolverSpHandle_t cusolver_sp_handle,
+                       matrix_type const &matrix, std::string const &solver);
+
+  virtual size_t m() const override final { return _matrix.m(); }
+
+  virtual size_t n() const override final { return _matrix.n(); }
+
+  virtual void apply(vector_type const &b, vector_type &x) const override final;
+
+  virtual std::shared_ptr<vector_type>
+  build_domain_vector() const override final;
+
+  virtual std::shared_ptr<vector_type>
+  build_range_vector() const override final;
+
+private:
+  cusolverDnHandle_t _cusolver_dn_handle;
+  cusolverSpHandle_t _cusolver_sp_handle;
+
+  matrix_type const &_matrix;
+
+  std::string _solver;
+};
+}
+
+#endif
+
+#endif

--- a/include/mfmg/dealii_operator_device.templates.cuh
+++ b/include/mfmg/dealii_operator_device.templates.cuh
@@ -1,0 +1,74 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_OPERATOR_DEVICE_TEMPLATES_CUH
+#define MFMG_DEALII_OPERATOR_DEVICE_TEMPLATES_CUH
+
+#include <mfmg/dealii_operator_device.cuh>
+#include <mfmg/dealii_operator_device_helpers.cuh>
+#include <mfmg/utils.cuh>
+
+#include <EpetraExt_Transpose_RowMatrix.h>
+
+#include <algorithm>
+
+namespace mfmg
+{
+template <typename VectorType>
+DirectDeviceOperator<VectorType>::DirectDeviceOperator(
+    cusolverDnHandle_t cusolver_dn_handle,
+    cusolverSpHandle_t cusolver_sp_handle,
+    SparseMatrixDevice<typename VectorType::value_type> const &matrix,
+    std::string const &solver)
+    : _cusolver_dn_handle(cusolver_dn_handle),
+      _cusolver_sp_handle(cusolver_sp_handle), _matrix(matrix), _solver(solver)
+{
+  // Transform to lower case
+  std::transform(_solver.begin(), _solver.end(), _solver.begin(), tolower);
+}
+
+template <typename VectorType>
+void DirectDeviceOperator<VectorType>::apply(VectorType const &b,
+                                             VectorType &x) const
+{
+  if (_solver == "cholesky")
+    cholesky_factorization(_cusolver_sp_handle, _matrix, b.get_values(),
+                           x.get_values());
+  else if (_solver == "lu_dense")
+    lu_factorization(_cusolver_dn_handle, _matrix, b.get_values(),
+                     x.get_values());
+  else if (_solver == "lu_sparse_host")
+    lu_factorization(_cusolver_sp_handle, _matrix, b.get_values(),
+                     x.get_values());
+  else
+    ASSERT_THROW(false, "The provided solver name " + _solver + " is invalid.");
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DirectDeviceOperator<VectorType>::build_domain_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+
+template <typename VectorType>
+std::shared_ptr<VectorType>
+DirectDeviceOperator<VectorType>::build_range_vector() const
+{
+  ASSERT_THROW_NOT_IMPLEMENTED();
+
+  return nullptr;
+}
+}
+
+#endif

--- a/include/mfmg/dealii_operator_device_helpers.cuh
+++ b/include/mfmg/dealii_operator_device_helpers.cuh
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_OPERATOR_DEVICE_HELPERS_CUH
+#define MFMG_DEALII_OPERATOR_DEVICE_HELPERS_CUH
+
+#include <mfmg/sparse_matrix_device.cuh>
+
+#include <cusolverSp.h>
+
+/**
+ * These functions are helper functions. There are mainly wrappers around
+ * cuSOLVER functions.
+ */
+
+namespace mfmg
+{
+void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                            SparseMatrixDevice<float> const &matrix,
+                            float const *b, float *x);
+
+void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                            SparseMatrixDevice<double> const &matrix,
+                            double const *b, double *x);
+template <typename ScalarType>
+void lu_factorization(cusolverDnHandle_t cusolver_dn_handle,
+                      SparseMatrixDevice<ScalarType> const &matrix,
+                      ScalarType const *b, ScalarType *x);
+
+template <typename ScalarType>
+void lu_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                      SparseMatrixDevice<ScalarType> const &matrix,
+                      ScalarType const *b, ScalarType *x);
+}
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -9,6 +9,7 @@ IF (${MFMG_ENABLE_CUDA})
   SET(MFMG_SOURCES
     ${MFMG_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/amge_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator_device_helpers.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_matrix_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cu
     )

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -9,6 +9,7 @@ IF (${MFMG_ENABLE_CUDA})
   SET(MFMG_SOURCES
     ${MFMG_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/amge_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator_device_helpers.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_matrix_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cu

--- a/source/dealii_operator_device.cu
+++ b/source/dealii_operator_device.cu
@@ -1,0 +1,15 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/dealii_operator_device.templates.cuh>
+#include <mfmg/vector_device.cuh>
+
+template class mfmg::DirectDeviceOperator<mfmg::VectorDevice<double>>;

--- a/source/dealii_operator_device_helpers.cu
+++ b/source/dealii_operator_device_helpers.cu
@@ -1,0 +1,272 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/dealii_operator_device_helpers.cuh>
+#include <mfmg/exceptions.hpp>
+#include <mfmg/utils.cuh>
+
+namespace mfmg
+{
+namespace internal
+{
+void cusparsecsr2dense(SparseMatrixDevice<float> const &matrix,
+                       float *dense_matrix_dev)
+{
+  cusparseStatus_t cusparse_error_code;
+  cusparse_error_code =
+      cusparseScsr2dense(matrix.cusparse_handle, matrix.m(), matrix.n(),
+                         matrix.descr, matrix.val_dev, matrix.row_ptr_dev,
+                         matrix.column_index_dev, dense_matrix_dev, matrix.m());
+  ASSERT_CUSPARSE(cusparse_error_code);
+}
+
+void cusparsecsr2dense(SparseMatrixDevice<double> const &matrix,
+                       double *dense_matrix_dev)
+{
+  cusparseStatus_t cusparse_error_code;
+  cusparse_error_code =
+      cusparseDcsr2dense(matrix.cusparse_handle, matrix.m(), matrix.n(),
+                         matrix.descr, matrix.val_dev, matrix.row_ptr_dev,
+                         matrix.column_index_dev, dense_matrix_dev, matrix.m());
+  ASSERT_CUSPARSE(cusparse_error_code);
+}
+
+void cusolverDngetrf_buffer_size(cusolverDnHandle_t cusolver_dn_handle, int m,
+                                 int n, float *dense_matrix_dev,
+                                 int &workspace_size)
+{
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code = cusolverDnSgetrf_bufferSize(
+      cusolver_dn_handle, m, n, dense_matrix_dev, m, &workspace_size);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverDngetrf_buffer_size(cusolverDnHandle_t cusolver_dn_handle, int m,
+                                 int n, double *dense_matrix_dev,
+                                 int &workspace_size)
+{
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code = cusolverDnDgetrf_bufferSize(
+      cusolver_dn_handle, m, n, dense_matrix_dev, m, &workspace_size);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverDngetrf(cusolverDnHandle_t cusolver_dn_handle, int m, int n,
+                     float *dense_matrix_dev, float *workspace_dev,
+                     int *pivot_dev, int *info_dev)
+{
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code =
+      cusolverDnSgetrf(cusolver_dn_handle, m, n, dense_matrix_dev, m,
+                       workspace_dev, pivot_dev, info_dev);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverDngetrf(cusolverDnHandle_t cusolver_dn_handle, int m, int n,
+                     double *dense_matrix_dev, double *workspace_dev,
+                     int *pivot_dev, int *info_dev)
+{
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code =
+      cusolverDnDgetrf(cusolver_dn_handle, m, n, dense_matrix_dev, m,
+                       workspace_dev, pivot_dev, info_dev);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverDngetrs(cusolverDnHandle_t cusolver_dn_handle, int m,
+                     float *dense_matrix_dev, int *pivot_dev, float *b,
+                     int *info_dev)
+{
+  int const n_rhs = 1;
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code =
+      cusolverDnSgetrs(cusolver_dn_handle, CUBLAS_OP_N, m, n_rhs,
+                       dense_matrix_dev, m, pivot_dev, b, m, info_dev);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverDngetrs(cusolverDnHandle_t cusolver_dn_handle, int m,
+                     double *dense_matrix_dev, int *pivot_dev, double *b,
+                     int *info_dev)
+{
+  int const n_rhs = 1;
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code =
+      cusolverDnDgetrs(cusolver_dn_handle, CUBLAS_OP_N, m, n_rhs,
+                       dense_matrix_dev, m, pivot_dev, b, m, info_dev);
+  ASSERT_CUSOLVER(cusolver_error_code);
+}
+
+void cusolverSpcsrlsvluHost(cusolverSpHandle_t cusolver_sp_handle,
+                            unsigned int const n_rows, unsigned int const nnz,
+                            cusparseMatDescr_t descr, float const *val_host,
+                            int const *row_ptr_host,
+                            int const *column_index_host, float const *b_host,
+                            float *x_host)
+{
+  int singularity = 0;
+  cusolverStatus_t cusolver_error_code = cusolverSpScsrlsvluHost(
+      cusolver_sp_handle, n_rows, nnz, descr, val_host, row_ptr_host,
+      column_index_host, b_host, 0., 1, x_host, &singularity);
+  ASSERT_CUSOLVER(cusolver_error_code);
+  ASSERT(singularity == -1, "Coarse matrix is singular");
+}
+
+void cusolverSpcsrlsvluHost(cusolverSpHandle_t cusolver_sp_handle,
+                            unsigned int const n_rows, unsigned int nnz,
+                            cusparseMatDescr_t descr, double const *val_host,
+                            int const *row_ptr_host,
+                            int const *column_index_host, double const *b_host,
+                            double *x_host)
+{
+  int singularity = 0;
+  cusolverStatus_t cusolver_error_code = cusolverSpDcsrlsvluHost(
+      cusolver_sp_handle, n_rows, nnz, descr, val_host, row_ptr_host,
+      column_index_host, b_host, 0., 1, x_host, &singularity);
+  ASSERT_CUSOLVER(cusolver_error_code);
+  ASSERT(singularity == -1, "Coarse matrix is singular");
+}
+}
+
+void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                            SparseMatrixDevice<float> const &matrix,
+                            float const *b, float *x)
+{
+  int singularity = 0;
+
+  cusolverStatus_t cusolver_error_code = cusolverSpScsrlsvchol(
+      cusolver_sp_handle, matrix.m(), matrix.n_nonzero_elements(), matrix.descr,
+      matrix.val_dev, matrix.row_ptr_dev, matrix.column_index_dev, b, 0., 0, x,
+      &singularity);
+  ASSERT_CUSOLVER(cusolver_error_code);
+
+  ASSERT(singularity == -1, "Coarse matrix is not SPD");
+}
+
+void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                            SparseMatrixDevice<double> const &matrix,
+                            double const *b, double *x)
+{
+  int singularity = 0;
+
+  cusolverStatus_t cusolver_error_code = cusolverSpDcsrlsvchol(
+      cusolver_sp_handle, matrix.m(), matrix.n_nonzero_elements(), matrix.descr,
+      matrix.val_dev, matrix.row_ptr_dev, matrix.column_index_dev, b, 0., 0, x,
+      &singularity);
+  ASSERT_CUSOLVER(cusolver_error_code);
+
+  ASSERT(singularity == -1, "Coarse matrix is not SPD");
+}
+
+template <typename ScalarType>
+void lu_factorization(cusolverDnHandle_t cusolver_dn_handle,
+                      SparseMatrixDevice<ScalarType> const &matrix,
+                      ScalarType const *b_dev, ScalarType *x_dev)
+{
+  // Change the format of the matrix from sparse to dense
+  unsigned int const m = matrix.m();
+  unsigned int const n = matrix.n();
+  ASSERT(m == n, "The matrix is not square");
+  ScalarType *dense_matrix_dev;
+  cuda_malloc(dense_matrix_dev, m * n);
+
+  // Change the format of matrix to dense
+  internal::cusparsecsr2dense(matrix, dense_matrix_dev);
+
+  // Create the working space
+  int workspace_size = 0;
+  internal::cusolverDngetrf_buffer_size(cusolver_dn_handle, m, n,
+                                        dense_matrix_dev, workspace_size);
+  ASSERT(workspace_size > 0, "No workspace was allocated");
+  ScalarType *workspace_dev;
+  cuda_malloc(workspace_dev, workspace_size);
+
+  // LU factorization
+  int *pivot_dev;
+  cuda_malloc(pivot_dev, m);
+  int *info_dev;
+  cuda_malloc(info_dev, 1);
+
+  internal::cusolverDngetrf(cusolver_dn_handle, m, n, dense_matrix_dev,
+                            workspace_dev, pivot_dev, info_dev);
+
+  cudaError_t cuda_error_code;
+#ifdef MFMG_DEBUG
+  int info = 0;
+  cuda_error_code =
+      cudaMemcpy(&info, info_dev, sizeof(int), cudaMemcpyDeviceToHost);
+  ASSERT_CUDA(cuda_error_code);
+  ASSERT(info == 0, "There was a problem during the LU factorization");
+#endif
+
+  // Solve Ax = b
+  cuda_error_code = cudaMemcpy(x_dev, b_dev, m * sizeof(ScalarType),
+                               cudaMemcpyDeviceToDevice);
+  ASSERT_CUDA(cuda_error_code);
+  internal::cusolverDngetrs(cusolver_dn_handle, m, dense_matrix_dev, pivot_dev,
+                            x_dev, info_dev);
+#ifdef MFMG_DEBUG
+  cuda_error_code =
+      cudaMemcpy(&info, info_dev, sizeof(int), cudaMemcpyDeviceToHost);
+  ASSERT_CUDA(cuda_error_code);
+  ASSERT(info == 0, "There was a problem during the LU solve");
+#endif
+
+  // Free the memory allocated
+  cuda_free(dense_matrix_dev);
+  cuda_free(workspace_dev);
+  cuda_free(pivot_dev);
+  cuda_free(info_dev);
+}
+
+template <typename ScalarType>
+void lu_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                      SparseMatrixDevice<ScalarType> const &matrix,
+                      ScalarType const *b_dev, ScalarType *x_dev)
+{
+  // cuSOLVER does not support LU factorization of sparse matrix on the device,
+  // so we need to move everything to the host first and then back to the host.
+  unsigned int const nnz = matrix.n_nonzero_elements();
+  unsigned int const n_rows = matrix.m();
+  std::vector<ScalarType> val_host(nnz);
+  std::vector<int> column_index_host(nnz);
+  std::vector<int> row_ptr_host(n_rows + 1);
+  cuda_mem_copy_to_host(matrix.val_dev, val_host);
+  cuda_mem_copy_to_host(matrix.column_index_dev, column_index_host);
+  cuda_mem_copy_to_host(matrix.row_ptr_dev, row_ptr_host);
+  std::vector<ScalarType> b_host(n_rows);
+  cuda_mem_copy_to_host(b_dev, b_host);
+  std::vector<ScalarType> x_host(n_rows);
+  cuda_mem_copy_to_host(x_dev, x_host);
+
+  internal::cusolverSpcsrlsvluHost(
+      cusolver_sp_handle, n_rows, nnz, matrix.descr, val_host.data(),
+      row_ptr_host.data(), column_index_host.data(), b_host.data(),
+      x_host.data());
+
+  // Move the solution back to the device
+  cuda_mem_copy_to_dev(x_host, x_dev);
+}
+
+template void lu_factorization<float>(cusolverDnHandle_t cusolver_dn_handle,
+                                      SparseMatrixDevice<float> const &matrix,
+                                      float const *b, float *x);
+template void lu_factorization<double>(cusolverDnHandle_t cusolver_dn_handle,
+                                       SparseMatrixDevice<double> const &matrix,
+                                       double const *b, double *x);
+
+template void lu_factorization<float>(cusolverSpHandle_t cusolver_sp_handle,
+                                      SparseMatrixDevice<float> const &matrix,
+                                      float const *b, float *x);
+template void lu_factorization<double>(cusolverSpHandle_t cusolver_sp_handle,
+                                       SparseMatrixDevice<double> const &matrix,
+                                       double const *b, double *x);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ IF(${MFMG_ENABLE_CUDA})
   MFMG_ADD_CUDA_TEST(test_eigenvectors_device 1)
   MFMG_ADD_CUDA_TEST(test_restriction_matrix_device 1)
   MFMG_ADD_CUDA_TEST(test_sparse_matrix_device 1 2 4)
+  MFMG_ADD_CUDA_TEST(test_direct_solver_device 1)
 ENDIF()
 
 MFMG_COPY_INPUT_FILE(hierarchy_input.info  tests/data)

--- a/tests/test_direct_solver_device.cu
+++ b/tests/test_direct_solver_device.cu
@@ -1,0 +1,117 @@
+/*************************************************************************
+ * Copyright (c) 2018 by the mfmg authors                                *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#define BOOST_TEST_MODULE direct_solver_device
+
+#include "main.cc"
+
+#include <mfmg/dealii_operator_device.cuh>
+#include <mfmg/exceptions.hpp>
+#include <mfmg/utils.cuh>
+
+#include <random>
+
+BOOST_AUTO_TEST_CASE(direct_solver)
+{
+  // Create the cusolver_dn_handle
+  cusolverDnHandle_t cusolver_dn_handle = nullptr;
+  cusolverStatus_t cusolver_error_code;
+  cusolver_error_code = cusolverDnCreate(&cusolver_dn_handle);
+  mfmg::ASSERT_CUSOLVER(cusolver_error_code);
+  // Create the cusolver_sp_handle
+  cusolverSpHandle_t cusolver_sp_handle = nullptr;
+  cusolver_error_code = cusolverSpCreate(&cusolver_sp_handle);
+  mfmg::ASSERT_CUSOLVER(cusolver_error_code);
+  // Create the cusparse_handle
+  cusparseHandle_t cusparse_handle = nullptr;
+  cusparseStatus_t cusparse_error_code;
+  cusparse_error_code = cusparseCreate(&cusparse_handle);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+
+  // Create the matrix on the host.
+  dealii::SparsityPattern sparsity_pattern;
+  dealii::SparseMatrix<double> matrix;
+  unsigned int const size = 30;
+  std::vector<std::vector<unsigned int>> column_indices(size);
+  for (unsigned int i = 0; i < size; ++i)
+  {
+    unsigned int j_max = std::min(size, i + 2);
+    unsigned int j_min = (i == 0) ? 0 : i - 1;
+    for (unsigned int j = j_min; j < j_max; ++j)
+      column_indices[i].emplace_back(j);
+  }
+  sparsity_pattern.copy_from(size, size, column_indices.begin(),
+                             column_indices.end());
+  matrix.reinit(sparsity_pattern);
+  for (unsigned int i = 0; i < size; ++i)
+  {
+    unsigned int j_max = std::min(size - 1, i + 1);
+    unsigned int j_min = (i == 0) ? 0 : i - 1;
+    matrix.set(i, j_min, -1.);
+    matrix.set(i, j_max, -1.);
+    matrix.set(i, i, 4.);
+  }
+
+  // Generate a random solution and then compute the rhs
+  dealii::Vector<double> sol_ref(size);
+  std::default_random_engine generator;
+  std::normal_distribution<> distribution(10., 2.);
+  for (auto &val : sol_ref)
+    val = distribution(generator);
+
+  dealii::Vector<double> rhs(size);
+  matrix.vmult(rhs, sol_ref);
+
+  // Move the matrix and the rhs to the host
+  mfmg::SparseMatrixDevice<double> matrix_dev(mfmg::convert_matrix(matrix));
+  matrix_dev.cusparse_handle = cusparse_handle;
+  cusparse_error_code = cusparseCreateMatDescr(&matrix_dev.descr);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code =
+      cusparseSetMatType(matrix_dev.descr, CUSPARSE_MATRIX_TYPE_GENERAL);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code =
+      cusparseSetMatIndexBase(matrix_dev.descr, CUSPARSE_INDEX_BASE_ZERO);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  auto partitioner =
+      std::make_shared<dealii::Utilities::MPI::Partitioner>(size);
+  mfmg::VectorDevice<double> rhs_dev(partitioner);
+  std::vector<double> rhs_host(size);
+  std::copy(rhs.begin(), rhs.end(), rhs_host.begin());
+  mfmg::cuda_mem_copy_to_dev(rhs_host, rhs_dev.val_dev);
+
+  for (auto solver : {"cholesky", "lu_dense", "lu_sparse_host"})
+  {
+    // Solve on the device
+    mfmg::DirectDeviceOperator<mfmg::VectorDevice<double>> direct_solver_dev(
+        cusolver_dn_handle, cusolver_sp_handle, matrix_dev, solver);
+    BOOST_CHECK_EQUAL(direct_solver_dev.m(), matrix_dev.m());
+    BOOST_CHECK_EQUAL(direct_solver_dev.n(), matrix_dev.n());
+    mfmg::VectorDevice<double> x_dev(partitioner);
+
+    direct_solver_dev.apply(rhs_dev, x_dev);
+
+    // Move the result back to the host
+    std::vector<double> x_host(size);
+    mfmg::cuda_mem_copy_to_host(x_dev.val_dev, x_host);
+
+    // Check the result
+    for (unsigned int i = 0; i < size; ++i)
+      BOOST_CHECK_CLOSE(x_host[i], sol_ref[i], 1e-12);
+  }
+
+  cusolver_error_code = cusolverDnDestroy(cusolver_dn_handle);
+  mfmg::ASSERT_CUSOLVER(cusolver_error_code);
+  cusolver_error_code = cusolverSpDestroy(cusolver_sp_handle);
+  mfmg::ASSERT_CUSOLVER(cusolver_error_code);
+  cusparse_error_code = cusparseDestroy(cusparse_handle);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+}


### PR DESCRIPTION
This PR adds direct solvers. The first commit is just a bunch of wrappers functions around `cuSOLVER` functions. This is because `cuSOLVER` uses different names for functions that take `float` or `double` as input. The second commit adds the direct solvers. There are three possible direct solvers: Cholesky for sparse matrix on the device, LU for dense matrix on the device, and LU for sparse matrix on the host. `cuSOLVER` does not have LU for sparse matrix on the device. Note that I've done the ETI for `VectorDevice` and for `dealii::LinearAlgebra::CUDAWrappers::Vector` because it was easier to write the test. I can remove this ETI. The last commit adds the test.