### PR TITLE
Add SparseMatrixDeviceOperator

### DIFF
--- a/include/mfmg/dealii_operator_device.cuh
+++ b/include/mfmg/dealii_operator_device.cuh
@@ -24,6 +24,41 @@
 namespace mfmg
 {
 template <typename VectorType>
+class SparseMatrixDeviceOperator : public MatrixOperator<VectorType>
+{
+public:
+  using value_type = typename VectorType::value_type;
+  using matrix_type = SparseMatrixDevice<value_type>;
+  using vector_type = VectorType;
+  using operator_type = MatrixOperator<vector_type>;
+
+  SparseMatrixDeviceOperator(std::shared_ptr<matrix_type> matrix);
+
+  virtual size_t m() const override final { return _matrix->m(); }
+
+  virtual size_t n() const override final { return _matrix->n(); }
+
+  size_t nnz() const { return _matrix->n_nonzero_elements(); }
+
+  virtual void apply(vector_type const &x, vector_type &y) const override final;
+
+  virtual std::shared_ptr<operator_type> transpose() const override final;
+
+  virtual std::shared_ptr<operator_type>
+  multiply(operator_type const &operator_b) const override final;
+
+  std::shared_ptr<matrix_type> get_matrix() const { return _matrix; }
+
+  virtual std::shared_ptr<vector_type>
+  build_domain_vector() const override final;
+
+  std::shared_ptr<vector_type> build_range_vector() const override final;
+
+private:
+  std::shared_ptr<matrix_type> _matrix;
+};
+
+template <typename VectorType>
 class DirectDeviceOperator : public Operator<VectorType>
 {
 public:

--- a/include/mfmg/dealii_operator_device.templates.cuh
+++ b/include/mfmg/dealii_operator_device.templates.cuh
@@ -67,7 +67,9 @@ SparseMatrixDeviceOperator<VectorType>::transpose() const
   for (unsigned int i = 0; i < n_local_rows; ++i)
   {
     unsigned int const row = rows[i];
-    unsigned int const n_cols = row_ptr[i + 1] - row_ptr[i];
+    // deal.II has functions that use pointers but the pointers need to be
+    // unsigned int instead of int. To avoid any problem, we set the elements
+    // one by one which makes sure that the cast is correct.
     for (unsigned int j = row_ptr[i]; j < row_ptr[i + 1]; ++j)
       sparse_matrix.set(row, column_index[j], values[j]);
   }

--- a/include/mfmg/sparse_matrix_device.cuh
+++ b/include/mfmg/sparse_matrix_device.cuh
@@ -33,6 +33,8 @@ public:
 
   SparseMatrixDevice(SparseMatrixDevice<ScalarType> &&other);
 
+  SparseMatrixDevice(SparseMatrixDevice<ScalarType> const &other);
+
   SparseMatrixDevice(MPI_Comm comm, ScalarType *val_dev, int *column_index_dev,
                      int *row_ptr_dev, unsigned int local_nnz,
                      dealii::IndexSet const &range_indexset,
@@ -70,6 +72,8 @@ public:
    */
   void mmult(SparseMatrixDevice<ScalarType> &C,
              SparseMatrixDevice<ScalarType> const &B) const;
+
+  MPI_Comm get_mpi_communicator() const { return _comm; }
 
   ScalarType *val_dev;
   int *column_index_dev;

--- a/include/mfmg/sparse_matrix_device.templates.cuh
+++ b/include/mfmg/sparse_matrix_device.templates.cuh
@@ -169,6 +169,43 @@ SparseMatrixDevice<ScalarType>::SparseMatrixDevice(
 
 template <typename ScalarType>
 SparseMatrixDevice<ScalarType>::SparseMatrixDevice(
+    SparseMatrixDevice<ScalarType> const &other)
+    : _comm(other._comm), cusparse_handle(other.cusparse_handle),
+      _local_nnz(other._local_nnz), _nnz(other._nnz),
+      _range_indexset(other._range_indexset),
+      _domain_indexset(other._domain_indexset)
+{
+  cuda_malloc(val_dev, _local_nnz);
+  cudaError_t cuda_error_code;
+  cuda_error_code =
+      cudaMemcpy(val_dev, other.val_dev, _local_nnz * sizeof(ScalarType),
+                 cudaMemcpyDeviceToDevice);
+  ASSERT_CUDA(cuda_error_code);
+
+  cuda_malloc(column_index_dev, _local_nnz);
+  cuda_error_code =
+      cudaMemcpy(column_index_dev, other.column_index_dev,
+                 _local_nnz * sizeof(int), cudaMemcpyDeviceToDevice);
+  ASSERT_CUDA(cuda_error_code);
+
+  unsigned int const size = _range_indexset.n_elements() + 1;
+  cuda_malloc(row_ptr_dev, size);
+  cuda_error_code = cudaMemcpy(row_ptr_dev, other.row_ptr_dev,
+                               size * sizeof(int), cudaMemcpyDeviceToDevice);
+  ASSERT_CUDA(cuda_error_code);
+
+  cusparseStatus_t cusparse_error_code;
+  cusparse_error_code = cusparseCreateMatDescr(&descr);
+  ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code = cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL);
+  ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code =
+      cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO);
+  ASSERT_CUSPARSE(cusparse_error_code);
+}
+
+template <typename ScalarType>
+SparseMatrixDevice<ScalarType>::SparseMatrixDevice(
     MPI_Comm comm, ScalarType *val_dev_, int *column_index_dev_,
     int *row_ptr_dev_, unsigned int local_nnz,
     dealii::IndexSet const &range_indexset,
@@ -266,6 +303,11 @@ void SparseMatrixDevice<ScalarType>::mmult(
   // TODO Communicate the values
 
   // Compute the number of non-zero elements in C
+  ASSERT(B.m() == n(), "The matrices cannot be multiplied together. You are "
+                       "trying to mutiply a " +
+                           std::to_string(m()) + " by " + std::to_string(n()) +
+                           " matrix with a " + std::to_string(B.m()) + " by " +
+                           std::to_string(B.n()));
   int C_local_nnz = 0;
   cusparseOperation_t cusparse_operation = CUSPARSE_OPERATION_NON_TRANSPOSE;
   cusparseStatus_t cusparse_error_code;

--- a/include/mfmg/sparse_matrix_device.templates.cuh
+++ b/include/mfmg/sparse_matrix_device.templates.cuh
@@ -329,7 +329,7 @@ void SparseMatrixDevice<ScalarType>::mmult(
       cudaMalloc(&C.column_index_dev, C_local_nnz * sizeof(ScalarType));
   ASSERT_CUDA(cuda_error_code);
   cuda_error_code =
-      cudaMalloc(&C.row_ptr_dev, C_local_nnz * sizeof(ScalarType));
+      cudaMalloc(&C.row_ptr_dev, n_local_rows() * sizeof(ScalarType));
   ASSERT_CUDA(cuda_error_code);
   C._local_nnz = C_local_nnz;
   C._range_indexset = _range_indexset;

--- a/source/dealii_operator_device.cu
+++ b/source/dealii_operator_device.cu
@@ -12,4 +12,6 @@
 #include <mfmg/dealii_operator_device.templates.cuh>
 #include <mfmg/vector_device.cuh>
 
+template class mfmg::SparseMatrixDeviceOperator<mfmg::VectorDevice<double>>;
+
 template class mfmg::DirectDeviceOperator<mfmg::VectorDevice<double>>;

--- a/source/utils.cu
+++ b/source/utils.cu
@@ -155,8 +155,9 @@ SparseMatrixDevice<double> convert_matrix(Epetra_CrsMatrix const &sparse_matrix)
   ASSERT_CUDA(cuda_error);
 
   int *row_ptr_dev;
-  cuda_malloc(row_ptr_dev, local_nnz);
-  cuda_error = cudaMemcpy(row_ptr_dev, row_ptr_host, local_nnz * sizeof(int),
+  unsigned int const row_ptr_size = n_local_rows + 1;
+  cuda_malloc(row_ptr_dev, row_ptr_size);
+  cuda_error = cudaMemcpy(row_ptr_dev, row_ptr_host, row_ptr_size * sizeof(int),
                           cudaMemcpyHostToDevice);
   ASSERT_CUDA(cuda_error);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ IF(${MFMG_ENABLE_CUDA})
   MFMG_ADD_CUDA_TEST(test_restriction_matrix_device 1)
   MFMG_ADD_CUDA_TEST(test_sparse_matrix_device 1 2 4)
   MFMG_ADD_CUDA_TEST(test_direct_solver_device 1)
+  MFMG_ADD_CUDA_TEST(test_sparse_matrix_device_operator 1)
 ENDIF()
 
 MFMG_COPY_INPUT_FILE(hierarchy_input.info  tests/data)

--- a/tests/test_sparse_matrix_device_operator.cu
+++ b/tests/test_sparse_matrix_device_operator.cu
@@ -1,0 +1,145 @@
+/*************************************************************************
+ * Copyright (c) 2018 by the mfmg authors                                *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#define BOOST_TEST_MODULE sparse_matrix_device_operator
+
+#include "main.cc"
+
+#include <mfmg/dealii_operator_device.cuh>
+#include <mfmg/utils.cuh>
+
+#include <set>
+#include <utility>
+
+BOOST_AUTO_TEST_CASE(matrix_operator)
+{
+  // Create the cusparse_handle
+  cusparseHandle_t cusparse_handle = nullptr;
+  cusparseStatus_t cusparse_error_code;
+  cusparse_error_code = cusparseCreate(&cusparse_handle);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+
+  unsigned int const n_rows = 30;
+  unsigned int const nnz_per_row = 10;
+  unsigned int const n_cols = n_rows + nnz_per_row - 1;
+  dealii::SparsityPattern sparsity_pattern;
+  std::vector<std::vector<unsigned int>> column_indices(
+      n_rows, std::vector<unsigned int>(nnz_per_row, 0));
+  std::set<std::pair<unsigned int, unsigned int>> sparsity_pattern_indices;
+  for (unsigned int i = 0; i < n_rows; ++i)
+    for (unsigned int j = 0; j < nnz_per_row; ++j)
+    {
+      column_indices[i][j] = i + j;
+      sparsity_pattern_indices.insert(std::make_pair(i, i + j));
+    }
+  sparsity_pattern.copy_from(n_rows, n_cols, column_indices.begin(),
+                             column_indices.end());
+  dealii::SparseMatrix<double> sparse_matrix(sparsity_pattern);
+  for (unsigned int i = 0; i < n_rows; ++i)
+    for (unsigned int j = 0; j < n_cols; ++j)
+      if (sparsity_pattern_indices.count(std::make_pair(i, j)) > 0)
+        sparse_matrix.set(i, j, static_cast<double>(i + j));
+
+  auto sparse_matrix_dev = std::make_shared<mfmg::SparseMatrixDevice<double>>(
+      mfmg::convert_matrix(sparse_matrix));
+  sparse_matrix_dev->cusparse_handle = cusparse_handle;
+  cusparse_error_code = cusparseCreateMatDescr(&sparse_matrix_dev->descr);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code = cusparseSetMatType(sparse_matrix_dev->descr,
+                                           CUSPARSE_MATRIX_TYPE_GENERAL);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  cusparse_error_code = cusparseSetMatIndexBase(sparse_matrix_dev->descr,
+                                                CUSPARSE_INDEX_BASE_ZERO);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+  mfmg::SparseMatrixDeviceOperator<mfmg::VectorDevice<double>> matrix_operator(
+      sparse_matrix_dev);
+  BOOST_CHECK_EQUAL(matrix_operator.m(), n_rows);
+  BOOST_CHECK_EQUAL(matrix_operator.n(), n_cols);
+
+  // Check build_domain_vector
+  auto domain_dev = matrix_operator.build_domain_vector();
+  BOOST_CHECK_EQUAL(domain_dev->partitioner->size(), n_cols);
+
+  // Check build_range_vector
+  auto range_dev = matrix_operator.build_range_vector();
+  BOOST_CHECK_EQUAL(range_dev->partitioner->size(), n_rows);
+
+  // Check apply
+  std::vector<double> domain_vector(n_cols, 1.);
+  mfmg::cuda_mem_copy_to_dev(domain_vector, domain_dev->get_values());
+  matrix_operator.apply(*domain_dev, *range_dev);
+  dealii::Vector<double> domain_dealii(domain_vector.begin(),
+                                       domain_vector.end());
+  dealii::Vector<double> range_dealii(n_rows);
+  sparse_matrix.vmult(range_dealii, domain_dealii);
+  std::vector<double> range_vector(n_rows);
+  mfmg::cuda_mem_copy_to_host(range_dev->val_dev, range_vector);
+  for (unsigned int i = 0; i < n_rows; ++i)
+    BOOST_CHECK_EQUAL(range_vector[i], range_dealii[i]);
+
+  // Check transpose
+  dealii::SparsityPattern transpose_sparsity_pattern;
+  std::vector<std::vector<unsigned int>> transpose_column_indices(n_cols);
+  for (unsigned int i = 0; i < n_cols; ++i)
+    for (unsigned int j = 0; j < n_rows; ++j)
+      if (sparsity_pattern_indices.count(std::make_pair(j, i)) > 0)
+        transpose_column_indices[i].emplace_back(j);
+  transpose_sparsity_pattern.copy_from(n_cols, n_rows,
+                                       transpose_column_indices.begin(),
+                                       transpose_column_indices.end());
+  dealii::SparseMatrix<double> transpose_sparse_matrix(
+      transpose_sparsity_pattern);
+  for (unsigned int i = 0; i < n_cols; ++i)
+    for (unsigned int j = 0; j < n_rows; ++j)
+      if (sparsity_pattern_indices.count(std::make_pair(j, i)) > 0)
+        transpose_sparse_matrix.set(i, j, static_cast<double>(i + j));
+  auto transpose_matrix_operator = matrix_operator.transpose();
+  BOOST_CHECK_EQUAL(transpose_matrix_operator->m(),
+                    transpose_sparse_matrix.m());
+  BOOST_CHECK_EQUAL(transpose_matrix_operator->n(),
+                    transpose_sparse_matrix.n());
+  // We don't have access to the underlying matrix directly so we apply the new
+  // operator and check the results
+  auto transpose_domain_dev = transpose_matrix_operator->build_domain_vector();
+  auto transpose_range_dev = transpose_matrix_operator->build_range_vector();
+  std::vector<double> transpose_domain_vector(transpose_matrix_operator->n(),
+                                              1.);
+  mfmg::cuda_mem_copy_to_dev(transpose_domain_vector,
+                             transpose_domain_dev->get_values());
+  transpose_matrix_operator->apply(*transpose_domain_dev, *transpose_range_dev);
+  dealii::Vector<double> transpose_domain_dealii(
+      transpose_domain_vector.begin(), transpose_domain_vector.end());
+  dealii::Vector<double> transpose_range_dealii(transpose_matrix_operator->m());
+  transpose_sparse_matrix.vmult(transpose_range_dealii,
+                                transpose_domain_dealii);
+  std::vector<double> transpose_range_vector(transpose_matrix_operator->m());
+  mfmg::cuda_mem_copy_to_host(transpose_range_dev->val_dev,
+                              transpose_range_vector);
+  for (unsigned int i = 0; i < n_rows; ++i)
+    BOOST_CHECK_EQUAL(transpose_range_vector[i], transpose_range_dealii[i]);
+
+  // Check multiply
+  sparse_matrix.vmult(range_dealii, transpose_range_dealii);
+  auto multiplied_matrix_operator =
+      matrix_operator.multiply(*transpose_matrix_operator);
+  multiplied_matrix_operator->apply(*transpose_domain_dev, *range_dev);
+  BOOST_CHECK_EQUAL(multiplied_matrix_operator->m(), sparse_matrix.m());
+  BOOST_CHECK_EQUAL(multiplied_matrix_operator->n(),
+                    transpose_sparse_matrix.n());
+
+  mfmg::cuda_mem_copy_to_host(range_dev->val_dev, range_vector);
+
+  for (unsigned int i = 0; i < n_rows; ++i)
+    BOOST_CHECK_EQUAL(range_vector[i], range_dealii[i]);
+
+  cusparse_error_code = cusparseDestroy(cusparse_handle);
+  mfmg::ASSERT_CUSPARSE(cusparse_error_code);
+}

--- a/tests/test_utils.cu
+++ b/tests/test_utils.cu
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(dealii_sparse_matrix_rectangle)
   dealii::SparsityPattern sparsity_pattern;
   unsigned int const n_rows = 30;
   unsigned int const nnz_per_row = 10;
-  unsigned int const n_cols = n_rows + nnz_per_row;
+  unsigned int const n_cols = n_rows + nnz_per_row - 1;
   std::vector<std::vector<unsigned int>> column_indices(
       n_rows, std::vector<unsigned int>(nnz_per_row));
   for (unsigned int i = 0; i < n_rows; ++i)


### PR DESCRIPTION
This adds the `SparseMatrixDevice` class. It's a pretty simple wrappers around `SparseMatrixDevice`. The main difficulty is to create the transpose of the matrix. Since this is an operation that's done only once, I move all the data to the host  then use `Epetra` to transpose the matrix and finally, I move it back to the device.

The first commit also fix a bug where the wrong amount of memory was allocated when moving an `Epetra_CrsMatrix` to the device.

Something I just realized is that I have implemented everything `dealii_operator_device.cuh` in analogy to `dealii_operator_device` but these classes don't really depend on `deal.II` so it might not be the best name.

PS: I'd like to have this PR merged today because the tester will be down for five days starting tomorrow.