### PR TITLE
Fix multiple bugs in SparseMatrixDevice

### DIFF
--- a/include/mfmg/sparse_matrix_device.cuh
+++ b/include/mfmg/sparse_matrix_device.cuh
@@ -65,7 +65,7 @@ public:
 
   unsigned int local_nnz() const { return _local_nnz; }
 
-  unsigned int n_nonzero_elements() const { return _nnz; };
+  unsigned int n_nonzero_elements() const { return _nnz; }
 
   dealii::IndexSet locally_owned_domain_indices() const;
 


### PR DESCRIPTION
Fix the following bugs:
 - the destructor did not set all pointers to nullptr after freeing the memory
 - in mmult, the arrays of resulting matrix were not allocated correctly
 (number of elements and datatype were wrong)
 - in mmult, the total number of non-zero elements was not set