### PR TITLE
Parallel mmult

### DIFF
--- a/include/mfmg/sparse_matrix_device.cuh
+++ b/include/mfmg/sparse_matrix_device.cuh
@@ -48,6 +48,9 @@ public:
 
   ~SparseMatrixDevice();
 
+  SparseMatrixDevice<ScalarType> &
+  operator=(SparseMatrixDevice<ScalarType> &&other);
+
   /**
    * Reinitialize the matrix. This can only be called if the object it empty.
    */

--- a/include/mfmg/sparse_matrix_device.templates.cuh
+++ b/include/mfmg/sparse_matrix_device.templates.cuh
@@ -370,38 +370,55 @@ void SparseMatrixDevice<ScalarType>::mmult(
     SparseMatrixDevice<ScalarType> &C,
     SparseMatrixDevice<ScalarType> const &B) const
 {
-  // TODO Communicate the values
-
   // Compute the number of non-zero elements in C
   ASSERT(B.m() == n(), "The matrices cannot be multiplied together. You are "
                        "trying to mutiply a " +
                            std::to_string(m()) + " by " + std::to_string(n()) +
                            " matrix with a " + std::to_string(B.m()) + " by " +
                            std::to_string(B.n()));
-  int C_local_nnz = 0;
-  cusparseOperation_t cusparse_operation = CUSPARSE_OPERATION_NON_TRANSPOSE;
-  cusparseStatus_t cusparse_error_code;
-  cusparse_error_code = cusparseXcsrgemmNnz(
-      cusparse_handle, cusparse_operation, cusparse_operation, n_local_rows(),
-      B.n(), n(), descr, local_nnz(), row_ptr_dev, column_index_dev, B.descr,
-      B.local_nnz(), B.row_ptr_dev, B.column_index_dev, C.descr, C.row_ptr_dev,
-      &C_local_nnz);
-  ASSERT_CUSPARSE(cusparse_error_code);
 
-  // Reinitialize part of C
-  cuda_free(C.val_dev);
-  cuda_free(C.column_index_dev);
-  cuda_free(C.row_ptr_dev);
-  cuda_malloc(C.val_dev, C_local_nnz);
-  cuda_malloc(C.column_index_dev, C_local_nnz);
-  cuda_malloc(C.row_ptr_dev, n_local_rows() + 1);
-  C._local_nnz = C_local_nnz;
-  C._nnz = C._local_nnz;
-  dealii::Utilities::MPI::sum(C._nnz, C._comm);
-  C._range_indexset = _range_indexset;
-  C._domain_indexset = B._domain_indexset;
+  unsigned int const comm_size = dealii::Utilities::MPI::n_mpi_processes(_comm);
 
-  internal::csrgemm(*this, B, C);
+  // If the code is serial then we can use cusparse directly. Otherwise, we need
+  // to use dealii.
+  if (comm_size == 1)
+  {
+    // Reinitialize part of C
+    cuda_free(C.row_ptr_dev);
+    cuda_malloc(C.row_ptr_dev, n_local_rows() + 1);
+
+    int C_local_nnz = 0;
+    cusparseOperation_t cusparse_operation = CUSPARSE_OPERATION_NON_TRANSPOSE;
+    cusparseStatus_t cusparse_error_code;
+    cusparse_error_code = cusparseXcsrgemmNnz(
+        cusparse_handle, cusparse_operation, cusparse_operation, n_local_rows(),
+        B.n(), n(), descr, local_nnz(), row_ptr_dev, column_index_dev, B.descr,
+        B.local_nnz(), B.row_ptr_dev, B.column_index_dev, C.descr,
+        C.row_ptr_dev, &C_local_nnz);
+    ASSERT_CUSPARSE(cusparse_error_code);
+
+    // Reinitialize part of C
+    cuda_free(C.val_dev);
+    cuda_free(C.column_index_dev);
+    cuda_malloc(C.val_dev, C_local_nnz);
+    cuda_malloc(C.column_index_dev, C_local_nnz);
+    C._local_nnz = C_local_nnz;
+    C._nnz = C._local_nnz;
+    C._range_indexset = _range_indexset;
+    C._domain_indexset = B._domain_indexset;
+
+    internal::csrgemm(*this, B, C);
+  }
+  else
+  {
+    dealii::TrilinosWrappers::SparseMatrix C_host;
+    auto A_host = convert_to_trilinos_matrix(*this);
+    auto B_host = convert_to_trilinos_matrix(B);
+
+    A_host.mmult(C_host, B_host);
+
+    C = convert_matrix(C_host);
+  }
 }
 }
 

--- a/include/mfmg/utils.cuh
+++ b/include/mfmg/utils.cuh
@@ -51,6 +51,9 @@ convert_matrix(dealii::TrilinosWrappers::SparseMatrix const &sparse_matrix);
 SparseMatrixDevice<double>
 convert_matrix(Epetra_CrsMatrix const &sparse_matrix);
 
+dealii::TrilinosWrappers::SparseMatrix
+convert_to_trilinos_matrix(SparseMatrixDevice<double> const &matrix_dev);
+
 template <typename T>
 inline void cuda_free(T *&pointer)
 {

--- a/source/sparse_matrix_device.cu
+++ b/source/sparse_matrix_device.cu
@@ -12,5 +12,4 @@
 #include <mfmg/sparse_matrix_device.templates.cuh>
 
 // Cannot use the instantiation macro with nvcc
-template class mfmg::SparseMatrixDevice<float>;
 template class mfmg::SparseMatrixDevice<double>;

--- a/source/utils.cu
+++ b/source/utils.cu
@@ -346,8 +346,6 @@ void all_gather_dev(MPI_Comm communicator, unsigned int send_count,
 }
 #endif
 
-template SparseMatrixDevice<float>
-convert_matrix(dealii::SparseMatrix<float> const &sparse_matrix);
 template SparseMatrixDevice<double>
 convert_matrix(dealii::SparseMatrix<double> const &sparse_matrix);
 }

--- a/tests/test_sparse_matrix_device.cu
+++ b/tests/test_sparse_matrix_device.cu
@@ -234,8 +234,15 @@ BOOST_AUTO_TEST_CASE(mmult)
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   unsigned int const comm_size = dealii::Utilities::MPI::n_mpi_processes(comm);
-  if (comm_size == 1)
+  int n_devices = 0;
+  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
+  mfmg::ASSERT_CUDA(cuda_error_code);
+  if ((comm_size == 1) || (comm_size == 2) && (n_devices == 2))
   {
+    int const rank = dealii::Utilities::MPI::this_mpi_process(comm);
+    cuda_error_code = cudaSetDevice(rank);
+    mfmg::ASSERT_CUDA(cuda_error_code);
+
     cusparseHandle_t cusparse_handle = nullptr;
     cusparseStatus_t cusparse_error_code;
     cusparse_error_code = cusparseCreate(&cusparse_handle);

--- a/tests/test_utils_device.cu
+++ b/tests/test_utils_device.cu
@@ -81,18 +81,18 @@ BOOST_AUTO_TEST_CASE(dealii_sparse_matrix_square)
                              column_indices.end());
 
   // Build the sparse matrix
-  dealii::SparseMatrix<float> sparse_matrix(sparsity_pattern);
+  dealii::SparseMatrix<double> sparse_matrix(sparsity_pattern);
   for (unsigned int i = 0; i < size; ++i)
     for (unsigned int j = 0; j < size; ++j)
       if (sparsity_pattern.exists(i, j))
-        sparse_matrix.set(i, j, static_cast<float>(i + j));
+        sparse_matrix.set(i, j, static_cast<double>(i + j));
 
   // Move the sparse matrix to the device and change the format to a regular CSR
-  mfmg::SparseMatrixDevice<float> sparse_matrix_dev =
+  mfmg::SparseMatrixDevice<double> sparse_matrix_dev =
       mfmg::convert_matrix(sparse_matrix);
 
   // Copy the matrix from the gpu
-  std::vector<float> val_host;
+  std::vector<double> val_host;
   std::vector<int> column_index_host;
   std::vector<int> row_ptr_host;
   std::tie(val_host, column_index_host, row_ptr_host) =
@@ -122,20 +122,20 @@ BOOST_AUTO_TEST_CASE(dealii_sparse_matrix_rectangle)
                              column_indices.end());
 
   // Build the sparse matrix
-  dealii::SparseMatrix<float> sparse_matrix(sparsity_pattern);
+  dealii::SparseMatrix<double> sparse_matrix(sparsity_pattern);
   for (unsigned int i = 0; i < n_rows; ++i)
     for (unsigned int j = 0; j < nnz_per_row; ++j)
-      sparse_matrix.set(i, i + j, static_cast<float>(i + j));
+      sparse_matrix.set(i, i + j, static_cast<double>(i + j));
 
   // Move the sparse matrix to the device and change the format to a regular CSR
-  mfmg::SparseMatrixDevice<float> sparse_matrix_dev =
+  mfmg::SparseMatrixDevice<double> sparse_matrix_dev =
       mfmg::convert_matrix(sparse_matrix);
 
   BOOST_CHECK_EQUAL(sparse_matrix_dev.m(), n_rows);
   BOOST_CHECK_EQUAL(sparse_matrix_dev.n(), n_cols);
 
   // Copy the matrix from the gpu
-  std::vector<float> val_host;
+  std::vector<double> val_host;
   std::vector<int> column_index_host;
   std::vector<int> row_ptr_host;
   std::tie(val_host, column_index_host, row_ptr_host) =

--- a/tests/test_utils_device.cu
+++ b/tests/test_utils_device.cu
@@ -219,6 +219,50 @@ BOOST_AUTO_TEST_CASE(trilinos_sparse_matrix)
   }
 }
 
+BOOST_AUTO_TEST_CASE(sparse_matrix_device)
+{
+  // Build the sparse matrix
+  unsigned int const comm_size =
+      dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  if (comm_size == 1)
+  {
+    unsigned int const n_local_rows = 10;
+    unsigned int const size = comm_size * n_local_rows;
+    dealii::IndexSet parallel_partitioning(size);
+    for (unsigned int i = 0; i < n_local_rows; ++i)
+      parallel_partitioning.add_index(i);
+    parallel_partitioning.compress();
+    dealii::TrilinosWrappers::SparseMatrix sparse_matrix(parallel_partitioning);
+
+    unsigned int nnz = 0;
+    for (unsigned int i = 0; i < n_local_rows; ++i)
+    {
+      std::default_random_engine generator(i);
+      std::uniform_int_distribution<int> distribution(0, size - 1);
+      std::set<int> column_indices;
+      for (unsigned int j = 0; j < 5; ++j)
+      {
+        int column_index = distribution(generator);
+        sparse_matrix.set(i, column_index, static_cast<double>(i + j));
+        column_indices.insert(column_index);
+      }
+      nnz += column_indices.size();
+    }
+    sparse_matrix.compress(dealii::VectorOperation::insert);
+
+    // Move the sparse matrix to the device.
+    auto sparse_matrix_dev = mfmg::convert_matrix(sparse_matrix);
+
+    // Move the sparse matrix back to the host
+    auto sparse_matrix_host =
+        mfmg::convert_to_trilinos_matrix(sparse_matrix_dev);
+
+    for (unsigned int i = 0; i < size; ++i)
+      for (unsigned int j = 0; j < size; ++j)
+        BOOST_CHECK_EQUAL(sparse_matrix_host.el(i, j), sparse_matrix.el(i, j));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(cuda_mpi)
 {
   MPI_Comm comm = MPI_COMM_WORLD;


### PR DESCRIPTION
In this PR, I've removed what was left of the `float` instantiation,  move code around to add a function that creates a `dealii::TrilinosWrappers::SparseMatrix` from a `SparseMatrixDevice`, and then use deal.II to do `mmult`. I have also moved around the destructor of `SparseMatrixDevice` because it was at the wrong place in the file but I haven't changed the code at all.