### PR TITLE
Encapsulate handles from the different libraries in one struct

### DIFF
--- a/include/mfmg/amge_device.cuh
+++ b/include/mfmg/amge_device.cuh
@@ -13,13 +13,11 @@
 #define AMGE_DEVICE_CUH
 
 #include <mfmg/amge.hpp>
+#include <mfmg/cuda_handle.cuh>
 #include <mfmg/exceptions.hpp>
 #include <mfmg/sparse_matrix_device.cuh>
 
 #include <deal.II/lac/cuda_vector.h>
-
-#include <cusolverDn.h>
-#include <cusparse.h>
 
 namespace mfmg
 {
@@ -30,8 +28,7 @@ public:
   using ScalarType = typename VectorType::value_type;
 
   AMGe_device(MPI_Comm comm, dealii::DoFHandler<dim> const &dof_handler,
-              cusolverDnHandle_t cusolver_dn_handle,
-              cusparseHandle_t cusparse_handle);
+              CudaHandle const &cuda_handle);
 
   /**
    * Compute the eigenvalues, the eigenvectors, the local diagonal elements, the
@@ -82,8 +79,7 @@ public:
           global_operator);
 
 private:
-  cusolverDnHandle_t _cusolver_dn_handle;
-  cusparseHandle_t _cusparse_handle;
+  CudaHandle const &_cuda_handle;
 };
 }
 

--- a/include/mfmg/cuda_handle.cuh
+++ b/include/mfmg/cuda_handle.cuh
@@ -1,0 +1,51 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef CUDA_HANDLE_CUH
+#define CUDA_HANDLE_CUH
+
+#include <cusolverDn.h>
+#include <cusolverSp.h>
+#include <cusparse.h>
+
+namespace mfmg
+{
+/**
+ * This structure creates, stores, and destroys the handles of the different
+ * CUDA libraries used inside deal.II.
+ */
+struct CudaHandle
+{
+  /**
+   * Constructor. Create the handles for the different libraries.
+   */
+  CudaHandle();
+
+  /**
+   * Copy constructor is deleted.
+   */
+  CudaHandle(CudaHandle const &) = delete;
+
+  /**
+   * Destructor. Destroy the handles and free all the memory allocated by
+   * GrowingVectorMemory.
+   */
+  ~CudaHandle();
+
+  cusolverDnHandle_t cusolver_dn_handle;
+
+  cusolverSpHandle_t cusolver_sp_handle;
+
+  cusparseHandle_t cusparse_handle;
+};
+}
+
+#endif

--- a/include/mfmg/dealii_operator_device.cuh
+++ b/include/mfmg/dealii_operator_device.cuh
@@ -15,11 +15,9 @@
 #ifdef MFMG_WITH_CUDA
 
 #include <mfmg/concepts.hpp>
+#include <mfmg/cuda_handle.cuh>
 #include <mfmg/exceptions.hpp>
 #include <mfmg/sparse_matrix_device.cuh>
-
-#include <cusolverDn.h>
-#include <cusolverSp.h>
 
 #if MFMG_WITH_AMGX
 #include <amgx_c.h>
@@ -111,9 +109,7 @@ public:
   using matrix_type = SparseMatrixDevice<value_type>;
   using operator_type = Operator<vector_type>;
 
-  DirectDeviceOperator(cusolverDnHandle_t const cusolver_dn_handle,
-                       cusolverSpHandle_t const cusolver_sp_handle,
-                       matrix_type const &matrix,
+  DirectDeviceOperator(CudaHandle const &cuda_handle, matrix_type const &matrix,
                        std::shared_ptr<boost::property_tree::ptree> params);
 
   virtual ~DirectDeviceOperator();
@@ -136,8 +132,8 @@ public:
   build_range_vector() const override final;
 
 private:
-  cusolverDnHandle_t _cusolver_dn_handle;
-  cusolverSpHandle_t _cusolver_sp_handle;
+  CudaHandle const &_cuda_handle;
+
   matrix_type const &_matrix;
   std::string _solver;
   std::string _amgx_config_file;

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -9,6 +9,7 @@ IF (${MFMG_ENABLE_CUDA})
   SET(MFMG_SOURCES
     ${MFMG_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/amge_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/cuda_handle.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/dealii_operator_device_helpers.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_matrix_device.cu

--- a/source/cuda_handle.cu
+++ b/source/cuda_handle.cu
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/cuda_handle.cuh>
+
+#include <mfmg/exceptions.hpp>
+
+namespace mfmg
+{
+CudaHandle::CudaHandle()
+    : cusolver_dn_handle(nullptr), cusolver_sp_handle(nullptr),
+      cusparse_handle(nullptr)
+{
+  // Create the dense cuSOLVER handle
+  cusolverStatus_t cusolver_error_code = cusolverDnCreate(&cusolver_dn_handle);
+  ASSERT_CUSOLVER(cusolver_error_code);
+  // Create the sparse cuSOLVER handle
+  cusolver_error_code = cusolverSpCreate(&cusolver_sp_handle);
+  ASSERT_CUSOLVER(cusolver_error_code);
+  // Create the cuSPARSE handle
+  cusparseStatus_t cusparse_error_code = cusparseCreate(&cusparse_handle);
+  ASSERT_CUSPARSE(cusparse_error_code);
+}
+
+CudaHandle::~CudaHandle()
+{
+  if (cusparse_handle != nullptr)
+  {
+    cusparseStatus_t cusparse_error_code = cusparseDestroy(cusparse_handle);
+    ASSERT_CUSPARSE(cusparse_error_code);
+    cusparse_handle = nullptr;
+  }
+
+  if (cusolver_sp_handle != nullptr)
+  {
+    cusolverStatus_t cusolver_error_code =
+        cusolverSpDestroy(cusolver_sp_handle);
+    ASSERT_CUSOLVER(cusolver_error_code);
+    cusolver_sp_handle = nullptr;
+  }
+
+  if (cusolver_dn_handle != nullptr)
+  {
+    cusolverStatus_t cusolver_error_code =
+        cusolverDnDestroy(cusolver_dn_handle);
+    ASSERT_CUSOLVER(cusolver_error_code);
+    cusolver_dn_handle = nullptr;
+  }
+}
+}


### PR DESCRIPTION
This doesn't change any functionality but it simplifies the code and, in particular, the tests. Instead of manually creating and destroying all the handles in the tests, this is now done automatically in the constructor and the destructor of the struct.