### PR TITLE
Add supports for zoltan and metis to build agglomerates

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -138,6 +138,7 @@ RUN export TRILINOS_HASH=996e8c2c2423564955e16a322b8b786121c5d2f0 && \
         -DTrilinos_ENABLE_ML=ON \
         -DTrilinos_ENABLE_MueLu=ON \
         -DTrilinos_ENABLE_Sacado=ON \
+        -DTrilinos_ENABLE_Zoltan=ON \
         -DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
         -DCMAKE_INSTALL_PREFIX=${TRILINOS_INSTALL_DIR} \
         ${TRILINOS_SOURCE_DIR} && \

--- a/include/mfmg/amge.hpp
+++ b/include/mfmg/amge.hpp
@@ -20,6 +20,8 @@
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparsity_pattern.h>
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <array>
 #include <map>
 #include <string>
@@ -33,12 +35,11 @@ public:
   AMGe(MPI_Comm comm, dealii::DoFHandler<dim> const &dof_handler);
 
   /**
-   * Flag cells to create agglomerates. The desired size of the agglomerates is
-   * given by \p agglomerate_dim. This functions returns the number of
-   * agglomerates that have been created.
+   * Flag cells to create agglomerates. This function returns the local number
+   * of agglomerates that have been created.
    */
-  unsigned int build_agglomerates(
-      std::array<unsigned int, dim> const &agglomerate_dim) const;
+  unsigned int
+  build_agglomerates(boost::property_tree::ptree const &ptree) const;
 
   /**
    * Create a Triangulation \p agglomerate_triangulation associated with an
@@ -85,6 +86,24 @@ protected:
   dealii::DoFHandler<dim> const &_dof_handler;
 
 private:
+  /**
+   * Flag cells to create agglomerates. The desired size of the agglomerates is
+   * given by \p agglomerate_dim. This function returns the local number of
+   * agglomerates that have been created.
+   */
+  unsigned int build_agglomerates_block(
+      std::array<unsigned int, dim> const &agglomerate_dim) const;
+
+  /**
+   * Flag cells to create agglomerates. \p partitioner_type is the partitioner
+   * used (zoltan or metis) and \p n_agglomerates is the local number of
+   * agglomerates that we would like to have. This function returns the local
+   * number of agglomerates that have been created.
+   */
+  unsigned int
+  build_agglomerates_partitioner(std::string const &partitioner_type,
+                                 unsigned int n_agglomerates) const;
+
   dealii::TrilinosWrappers::SparsityPattern
   compute_restriction_sparsity_pattern(
       std::vector<dealii::Vector<double>> const &eigenvectors,

--- a/include/mfmg/amge_device.cuh
+++ b/include/mfmg/amge_device.cuh
@@ -72,7 +72,7 @@ public:
    *  Build the agglomerates and their associated triangulations.
    */
   mfmg::SparseMatrixDevice<typename VectorType::value_type> setup_restrictor(
-      std::array<unsigned int, dim> const &agglomerate_dim,
+      boost::property_tree::ptree const &agglomerate_dim,
       unsigned int const n_eigenvectors, double const tolerance,
       MeshEvaluator const &evaluator,
       std::shared_ptr<typename MeshEvaluator::global_operator_type const>

--- a/include/mfmg/amge_device.templates.cuh
+++ b/include/mfmg/amge_device.templates.cuh
@@ -353,7 +353,7 @@ AMGe_device<dim, MeshEvaluator, VectorType>::compute_restriction_sparse_matrix(
 template <int dim, typename MeshEvaluator, typename VectorType>
 mfmg::SparseMatrixDevice<typename VectorType::value_type>
 AMGe_device<dim, MeshEvaluator, VectorType>::setup_restrictor(
-    std::array<unsigned int, dim> const &agglomerate_dim,
+    boost::property_tree::ptree const &agglomerate_dim,
     unsigned int const n_eigenvectors, double const tolerance,
     MeshEvaluator const &evaluator,
     std::shared_ptr<typename MeshEvaluator::global_operator_type const>

--- a/include/mfmg/amge_host.hpp
+++ b/include/mfmg/amge_host.hpp
@@ -73,7 +73,7 @@ public:
    *  Build the agglomerates and their associated triangulations.
    */
   void setup_restrictor(
-      std::array<unsigned int, dim> const &agglomerate_dim,
+      boost::property_tree::ptree const &agglomerate_dim,
       unsigned int const n_eigenvectors, double const tolerance,
       MeshEvaluator const &evaluator,
       std::shared_ptr<typename MeshEvaluator::global_operator_type const>

--- a/include/mfmg/amge_host.templates.hpp
+++ b/include/mfmg/amge_host.templates.hpp
@@ -178,7 +178,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::
 
 template <int dim, typename MeshEvaluator, typename VectorType>
 void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
-    std::array<unsigned int, dim> const &agglomerate_dim,
+    boost::property_tree::ptree const &agglomerate_ptree,
     unsigned int const n_eigenvectors, double const tolerance,
     MeshEvaluator const &evaluator,
     std::shared_ptr<typename MeshEvaluator::global_operator_type const>
@@ -186,7 +186,8 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
     dealii::TrilinosWrappers::SparseMatrix &restriction_sparse_matrix)
 {
   // Flag the cells to build agglomerates.
-  unsigned int const n_agglomerates = this->build_agglomerates(agglomerate_dim);
+  unsigned int const n_agglomerates =
+      this->build_agglomerates(agglomerate_ptree);
 
   // Parallel part of the setup.
   std::vector<unsigned int> agglomerate_ids(n_agglomerates);

--- a/include/mfmg/dealii_adapters.hpp
+++ b/include/mfmg/dealii_adapters.hpp
@@ -149,20 +149,15 @@ public:
     AMGe_host<mesh_type::dimension(), mesh_evaluator_type, vector_type> amge(
         comm, mesh._dof_handler, eigensolver_params.get("type", "arpack"));
 
-    std::array<unsigned int, dim> agglomerate_dim;
     auto agglomerate_params = params->get_child("agglomeration");
-    agglomerate_dim[0] = agglomerate_params.get<unsigned int>("nx");
-    agglomerate_dim[1] = agglomerate_params.get<unsigned int>("ny");
-    if (dim == 3)
-      agglomerate_dim[2] = agglomerate_params.get<unsigned int>("nz");
     int n_eigenvectors = eigensolver_params.get("number of eigenvectors", 1);
     double tolerance = eigensolver_params.get("tolerance", 1e-14);
 
     auto restrictor_matrix =
         std::make_shared<typename global_operator_type::matrix_type>();
     auto global_operator = evaluator.get_global_operator(mesh);
-    amge.setup_restrictor(agglomerate_dim, n_eigenvectors, tolerance, evaluator,
-                          global_operator, *restrictor_matrix);
+    amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
+                          evaluator, global_operator, *restrictor_matrix);
 
     return std::make_shared<global_operator_type>(restrictor_matrix);
   }

--- a/include/mfmg/dealii_adapters_device.cuh
+++ b/include/mfmg/dealii_adapters_device.cuh
@@ -113,12 +113,7 @@ public:
     AMGe_device<mesh_type::dimension(), mesh_evaluator_type, vector_type> amge(
         comm, mesh._dof_handler, evaluator.cuda_handle);
 
-    std::array<unsigned int, dim> agglomerate_dim;
     auto agglomerate_params = params->get_child("agglomeration");
-    agglomerate_dim[0] = agglomerate_params.get<unsigned int>("nx");
-    agglomerate_dim[1] = agglomerate_params.get<unsigned int>("ny");
-    if (dim == 3)
-      agglomerate_dim[2] = agglomerate_params.get<unsigned int>("nz");
     int n_eigenvectors = eigensolver_params.get("number of eigenvectors", 1);
     double tolerance = eigensolver_params.get("tolerance", 1e-14);
 
@@ -126,7 +121,7 @@ public:
 
     auto restrictor_matrix =
         std::make_shared<typename global_operator_type::matrix_type>(
-            amge.setup_restrictor(agglomerate_dim, n_eigenvectors, tolerance,
+            amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
                                   evaluator, global_operator));
 
     return std::make_shared<global_operator_type>(restrictor_matrix);

--- a/tests/data/hierarchy_input.info
+++ b/tests/data/hierarchy_input.info
@@ -13,6 +13,7 @@ smoother
 
 agglomeration
 {
+  partitioner block
   nx 2
   ny 2
   nz 2

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -273,9 +273,7 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-14))
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
   params->put("eigensolver.number of eigenvectors", 1);
-  std::array<unsigned int, dim> agglomerate_dim;
-  agglomerate_dim[0] = params->get<unsigned int>("agglomeration.nx");
-  agglomerate_dim[1] = params->get<unsigned int>("agglomeration.ny");
+  auto agglomerate_ptree = params->get_child("agglomeration");
   int n_eigenvectors =
       params->get<int>("eigensolver.number of eigenvectors", 1);
   double tolerance = params->get<double>("eigensolver.tolerance", 1e-14);
@@ -297,7 +295,7 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-14))
   auto restrictor_matrix = std::make_shared<typename mfmg::DealIIMeshEvaluator<
       dim, MeshEvaluator>::global_operator_type::matrix_type>();
   auto global_operator = evaluator.get_global_operator(*mesh);
-  amge.setup_restrictor(agglomerate_dim, n_eigenvectors, tolerance, evaluator,
+  amge.setup_restrictor(agglomerate_ptree, n_eigenvectors, tolerance, evaluator,
                         global_operator, *restrictor_matrix);
 
   // Multiply the matrix by three because all the eigenvectors are 1/3. So we


### PR DESCRIPTION
This adds the possibility to use zoltan or metis to create the agglomerate. Since zoltan and metis are called locally on each processor, agglomerates cannot cross processor boundary. This PR adds a new function `build_agglomerates_partitioner` and move `build_agglomerates` to `build_agglomerates_block`.