### PR TITLE
Improve include order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,25 @@ BasedOnStyle:  LLVM
 Language:        Cpp
 AlwaysBreakTemplateDeclarations: true
 BreakBeforeBraces: Allman
+IncludeBlocks: Regroup
+IncludeCategories:
+# mfmg first
+  - Regex: "mfmg/*"
+    Priority: 100
+# Then deal.II
+  - Regex: "deal.II/*"
+    Priority: 200
+# Then Trilinos
+  - Regex: "Epetra_*"
+    Priority: 300
+  - Regex: "ml_*"
+    Priority: 310
+  - Regex: "Teuchos_*"
+    Priority: 320
+# Then boost
+  - Regex: "boost*"
+    Priority: 400
+# Finally the standard library
+  - Regex: "<[a-z_]+>"
+    Priority: 1000
 ...

--- a/include/mfmg/amge.templates.hpp
+++ b/include/mfmg/amge.templates.hpp
@@ -13,7 +13,6 @@
 #define AMG_TEMPLATES_HPP
 
 #include <mfmg/amge.hpp>
-
 #include <mfmg/exceptions.hpp>
 
 #include <deal.II/distributed/tria.h>

--- a/include/mfmg/amge_device.templates.cuh
+++ b/include/mfmg/amge_device.templates.cuh
@@ -14,7 +14,6 @@
 
 #include <mfmg/amge.templates.hpp>
 #include <mfmg/amge_device.cuh>
-
 #include <mfmg/utils.cuh>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/include/mfmg/cuda_mesh_evaluator.cuh
+++ b/include/mfmg/cuda_mesh_evaluator.cuh
@@ -14,10 +14,9 @@
 
 #ifdef MFMG_WITH_CUDA
 
-#include <mfmg/mesh_evaluator.hpp>
-
 #include <mfmg/cuda_handle.cuh>
 #include <mfmg/exceptions.hpp>
+#include <mfmg/mesh_evaluator.hpp>
 #include <mfmg/sparse_matrix_device.cuh>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/include/mfmg/dealii_mesh_evaluator.hpp
+++ b/include/mfmg/dealii_mesh_evaluator.hpp
@@ -12,9 +12,8 @@
 #ifndef MFMG_DEALII_MESH_EVALUATOR_HPP
 #define MFMG_DEALII_MESH_EVALUATOR_HPP
 
-#include <mfmg/mesh_evaluator.hpp>
-
 #include <mfmg/exceptions.hpp>
+#include <mfmg/mesh_evaluator.hpp>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/affine_constraints.h>

--- a/include/mfmg/hierarchy_helpers.hpp
+++ b/include/mfmg/hierarchy_helpers.hpp
@@ -19,9 +19,9 @@
 
 #include <boost/property_tree/ptree.hpp>
 
-#include <mpi.h>
-
 #include <memory>
+
+#include <mpi.h>
 
 namespace mfmg
 {

--- a/include/mfmg/utils.hpp
+++ b/include/mfmg/utils.hpp
@@ -18,6 +18,7 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <Teuchos_ParameterList.hpp>
+
 #include <boost/property_tree/ptree.hpp>
 
 #include <algorithm>

--- a/source/amge_device.cu
+++ b/source/amge_device.cu
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/amge_device.templates.cuh>
-
 #include <mfmg/cuda_mesh_evaluator.cuh>
 #include <mfmg/vector_device.cuh>
 

--- a/source/cuda_handle.cu
+++ b/source/cuda_handle.cu
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/cuda_handle.cuh>
-
 #include <mfmg/exceptions.hpp>
 
 namespace mfmg

--- a/source/cuda_hierarchy_helpers.cu
+++ b/source/cuda_hierarchy_helpers.cu
@@ -9,9 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/cuda_hierarchy_helpers.cuh>
-
 #include <mfmg/amge_device.cuh>
+#include <mfmg/cuda_hierarchy_helpers.cuh>
 #include <mfmg/cuda_matrix_operator.cuh>
 #include <mfmg/cuda_mesh_evaluator.cuh>
 #include <mfmg/cuda_smoother.cuh>

--- a/source/cuda_smoother.cu
+++ b/source/cuda_smoother.cu
@@ -9,9 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/cuda_smoother.cuh>
-
 #include <mfmg/cuda_matrix_operator.cuh>
+#include <mfmg/cuda_smoother.cuh>
 #include <mfmg/dealii_operator_device_helpers.cuh>
 
 namespace mfmg

--- a/source/dealii_hierarchy_helpers.cc
+++ b/source/dealii_hierarchy_helpers.cc
@@ -9,9 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/dealii_hierarchy_helpers.hpp>
-
 #include <mfmg/amge_host.hpp>
+#include <mfmg/dealii_hierarchy_helpers.hpp>
 #include <mfmg/dealii_mesh_evaluator.hpp>
 #include <mfmg/dealii_smoother.hpp>
 #include <mfmg/dealii_solver.hpp>

--- a/source/dealii_matrix_operator.cc
+++ b/source/dealii_matrix_operator.cc
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/dealii_matrix_operator.hpp>
-
 #include <mfmg/exceptions.hpp>
 #include <mfmg/instantiation.hpp>
 

--- a/source/dealii_mesh_evaluator.cc
+++ b/source/dealii_mesh_evaluator.cc
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/dealii_mesh_evaluator.hpp>
-
 #include <mfmg/instantiation.hpp>
 
 namespace mfmg

--- a/source/dealii_smoother.cc
+++ b/source/dealii_smoother.cc
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/dealii_smoother.hpp>
-
 #include <mfmg/dealii_trilinos_matrix_operator.hpp>
 #include <mfmg/exceptions.hpp>
 #include <mfmg/instantiation.hpp>

--- a/source/dealii_trilinos_matrix_operator.cc
+++ b/source/dealii_trilinos_matrix_operator.cc
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 #include <mfmg/dealii_trilinos_matrix_operator.hpp>
-
 #include <mfmg/exceptions.hpp>
 #include <mfmg/instantiation.hpp>
 

--- a/source/utils.cc
+++ b/source/utils.cc
@@ -14,6 +14,7 @@
 
 #include <EpetraExt_MultiVectorOut.h>
 #include <EpetraExt_RowMatrixOut.h>
+
 #include <Teuchos_XMLParameterListCoreHelpers.hpp>
 
 #include <string>

--- a/source/utils.cu
+++ b/source/utils.cu
@@ -9,9 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/utils.cuh>
-
 #include <mfmg/sparse_matrix_device.cuh>
+#include <mfmg/utils.cuh>
 #include <mfmg/utils.hpp>
 
 #include <deal.II/lac/trilinos_index_access.h>

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -1,8 +1,8 @@
-#include "test_hierarchy_helpers.hpp"
-
 #include <mfmg/exceptions.hpp>
 
 #include <boost/program_options.hpp>
+
+#include "test_hierarchy_helpers.hpp"
 
 template <int dim>
 void main_(std::shared_ptr<boost::property_tree::ptree> params)

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -11,8 +11,9 @@
 
 #define BOOST_TEST_NO_MAIN
 
-#include <boost/test/unit_test.hpp>
 #include <deal.II/base/mpi.h>
+
+#include <boost/test/unit_test.hpp>
 
 bool init_function() { return true; }
 

--- a/tests/test_agglomerate.cc
+++ b/tests/test_agglomerate.cc
@@ -11,8 +11,6 @@
 
 #define BOOST_TEST_MODULE agglomerate
 
-#include "main.cc"
-
 #include <mfmg/amge_host.hpp>
 #include <mfmg/dealii_mesh_evaluator.hpp>
 
@@ -21,10 +19,11 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/numerics/data_out.h>
 
 #include <array>
 
-#include <deal.II/numerics/data_out.h>
+#include "main.cc"
 
 template <int dim>
 std::vector<unsigned int> test(MPI_Comm const &world)

--- a/tests/test_amgx_direct_solver.cu
+++ b/tests/test_amgx_direct_solver.cu
@@ -20,6 +20,7 @@
 #include <mfmg/vector_device.cuh>
 
 #include <boost/property_tree/ptree.hpp>
+
 #include <cusolverDn.h>
 #include <cusolverSp.h>
 

--- a/tests/test_direct_solver_device.cu
+++ b/tests/test_direct_solver_device.cu
@@ -11,14 +11,14 @@
 
 #define BOOST_TEST_MODULE direct_solver_device
 
-#include "main.cc"
-
 #include <mfmg/cuda_matrix_operator.cuh>
 #include <mfmg/cuda_solver.cuh>
 #include <mfmg/exceptions.hpp>
 #include <mfmg/utils.cuh>
 
 #include <random>
+
+#include "main.cc"
 
 BOOST_AUTO_TEST_CASE(direct_solver)
 {

--- a/tests/test_eigenvectors.cc
+++ b/tests/test_eigenvectors.cc
@@ -11,8 +11,6 @@
 
 #define BOOST_TEST_MODULE eigenvectors
 
-#include "main.cc"
-
 #include <mfmg/amge_host.hpp>
 #include <mfmg/dealii_mesh_evaluator.hpp>
 
@@ -23,6 +21,8 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <algorithm>
+
+#include "main.cc"
 
 namespace tt = boost::test_tools;
 namespace ut = boost::unit_test;

--- a/tests/test_eigenvectors_device.cu
+++ b/tests/test_eigenvectors_device.cu
@@ -11,8 +11,6 @@
 
 #define BOOST_TEST_MODULE eigenvectors_device
 
-#include "main.cc"
-
 #include <mfmg/amge_device.cuh>
 #include <mfmg/cuda_mesh_evaluator.cuh>
 #include <mfmg/sparse_matrix_device.cuh>
@@ -23,6 +21,8 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/lac/la_parallel_vector.h>
+
+#include "main.cc"
 
 template <int dim>
 class DiagonalTestMeshEvaluator : public mfmg::CudaMeshEvaluator<dim>

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -11,11 +11,6 @@
 
 #define BOOST_TEST_MODULE hierarchy
 
-#include "main.cc"
-
-#include "laplace.hpp"
-#include "test_hierarchy_helpers.hpp"
-
 #include <mfmg/hierarchy.hpp>
 
 #include <deal.II/base/conditional_ostream.h>
@@ -34,6 +29,10 @@
 #include <boost/test/data/test_case.hpp>
 
 #include <random>
+
+#include "laplace.hpp"
+#include "main.cc"
+#include "test_hierarchy_helpers.hpp"
 
 namespace bdata = boost::unit_test::data;
 namespace tt = boost::test_tools;

--- a/tests/test_hierarchy_device.cu
+++ b/tests/test_hierarchy_device.cu
@@ -11,15 +11,14 @@
 
 #define BOOST_TEST_MODULE hierarchy_boost
 
-#include "main.cc"
-
-#include "laplace.hpp"
-
 #include <mfmg/hierarchy.hpp>
 
 #include <deal.II/base/conditional_ostream.h>
 
 #include <boost/property_tree/info_parser.hpp>
+
+#include "laplace.hpp"
+#include "main.cc"
 
 template <int dim>
 class Source : public dealii::Function<dim>

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -12,8 +12,6 @@
 #ifndef MFMG_TEST_HIERARCHY_HELPERS_HPP
 #define MFMG_TEST_HIERARCHY_HELPERS_HPP
 
-#include "laplace.hpp"
-
 #include <mfmg/dealii_mesh_evaluator.hpp>
 #include <mfmg/hierarchy.hpp>
 
@@ -31,6 +29,8 @@
 #include <boost/test/data/test_case.hpp>
 
 #include <random>
+
+#include "laplace.hpp"
 
 namespace bdata = boost::unit_test::data;
 namespace tt = boost::test_tools;

--- a/tests/test_laplace.cc
+++ b/tests/test_laplace.cc
@@ -11,11 +11,12 @@
 
 #define BOOST_TEST_MODULE laplace
 
-#include "laplace.hpp"
-#include "main.cc"
 #include <deal.II/lac/trilinos_precondition.h>
 
 #include <cstdio>
+
+#include "laplace.hpp"
+#include "main.cc"
 
 namespace tt = boost::test_tools;
 

--- a/tests/test_laplace_matrix_free.cc
+++ b/tests/test_laplace_matrix_free.cc
@@ -11,10 +11,10 @@
 
 #define BOOST_TEST_MODULE laplace_matrix_free
 
+#include <deal.II/lac/precondition.h>
+
 #include "laplace_matrix_free.hpp"
 #include "main.cc"
-
-#include <deal.II/lac/precondition.h>
 
 namespace tt = boost::test_tools;
 

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -11,10 +11,6 @@
 
 #define BOOST_TEST_MODULE restriction
 
-#include "main.cc"
-
-#include "laplace.hpp"
-
 #include <mfmg/amge_host.hpp>
 #include <mfmg/dealii_mesh_evaluator.hpp>
 
@@ -27,6 +23,9 @@
 #include <boost/property_tree/info_parser.hpp>
 
 #include <random>
+
+#include "laplace.hpp"
+#include "main.cc"
 
 namespace utf = boost::unit_test;
 

--- a/tests/test_restriction_matrix_device.cu
+++ b/tests/test_restriction_matrix_device.cu
@@ -11,8 +11,6 @@
 
 #define BOOST_TEST_MODULE restriction_device
 
-#include "main.cc"
-
 #include <mfmg/amge_device.cuh>
 #include <mfmg/cuda_mesh_evaluator.cuh>
 #include <mfmg/sparse_matrix_device.cuh>
@@ -25,6 +23,8 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/lac/la_parallel_vector.h>
+
+#include "main.cc"
 
 template <int dim>
 class DummyMeshEvaluator : public mfmg::CudaMeshEvaluator<dim>

--- a/tests/test_smoother_device.cu
+++ b/tests/test_smoother_device.cu
@@ -11,8 +11,6 @@
 
 #define BOOST_TEST_MODULE smoother_device
 
-#include "main.cc"
-
 #include <mfmg/cuda_matrix_operator.cuh>
 #include <mfmg/cuda_smoother.cuh>
 #include <mfmg/sparse_matrix_device.cuh>
@@ -20,6 +18,8 @@
 #include <deal.II/lac/precondition.h>
 
 #include <boost/property_tree/ptree.hpp>
+
+#include "main.cc"
 
 BOOST_AUTO_TEST_CASE(smoother)
 {

--- a/tests/test_sparse_matrix_device.cu
+++ b/tests/test_sparse_matrix_device.cu
@@ -11,14 +11,14 @@
 
 #define BOOST_TEST_MODULE utils
 
-#include "main.cc"
-
 #include <mfmg/sparse_matrix_device.cuh>
 #include <mfmg/utils.cuh>
 
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include <set>
+
+#include "main.cc"
 
 BOOST_AUTO_TEST_CASE(serial_mv)
 {

--- a/tests/test_sparse_matrix_device_operator.cu
+++ b/tests/test_sparse_matrix_device_operator.cu
@@ -11,14 +11,14 @@
 
 #define BOOST_TEST_MODULE sparse_matrix_device_operator
 
-#include "main.cc"
-
 #include <mfmg/cuda_matrix_operator.cuh>
 #include <mfmg/sparse_matrix_device.cuh>
 #include <mfmg/utils.cuh>
 
 #include <set>
 #include <utility>
+
+#include "main.cc"
 
 BOOST_AUTO_TEST_CASE(matrix_operator)
 {

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -11,13 +11,14 @@
 
 #define BOOST_TEST_MODULE utils
 
-#include "main.cc"
-
 #include <mfmg/utils.hpp>
 
 #include <Teuchos_ParameterList.hpp>
+
 #include <boost/property_tree/info_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+
+#include "main.cc"
 
 BOOST_AUTO_TEST_CASE(plist2ptree)
 {

--- a/tests/test_utils_device.cu
+++ b/tests/test_utils_device.cu
@@ -11,11 +11,8 @@
 
 #define BOOST_TEST_MODULE utils_device
 
-#include "main.cc"
-
-#include <mfmg/utils.cuh>
-
 #include <mfmg/sparse_matrix_device.cuh>
+#include <mfmg/utils.cuh>
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/lac/sparse_matrix.h>
@@ -25,6 +22,8 @@
 #include <algorithm>
 #include <random>
 #include <set>
+
+#include "main.cc"
 
 template <typename ScalarType>
 std::vector<ScalarType> copy_to_host(ScalarType *val_dev,


### PR DESCRIPTION
This PR improves clang-format so that the headers from the same library are grouped together.