### PR TITLE
Implement MatrixFreeHierarchyHelpers

### DIFF
--- a/include/mfmg/common/amge.templates.hpp
+++ b/include/mfmg/common/amge.templates.hpp
@@ -26,6 +26,17 @@
 #include <map>
 #include <unordered_map>
 
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+// Zoltan random seed control is in an internal zz_rand.h file which is not
+// installed with Trilinos. Thus, we duplicate the signature and the
+// initialization value here.
+#define ZOLTAN_RAND_INIT 123456789U
+extern "C"
+{
+  extern void Zoltan_Srand(unsigned int, unsigned int *);
+}
+#endif
+
 namespace mfmg
 {
 template <int dim, typename VectorType>
@@ -44,6 +55,10 @@ unsigned int AMGe<dim, VectorType>::build_agglomerates(
                  partitioner_type.begin(), ::tolower);
   if ((partitioner_type == "zoltan") || (partitioner_type == "metis"))
   {
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+    // Always use the same seed for Zoltan
+    Zoltan_Srand(ZOLTAN_RAND_INIT, NULL);
+#endif
     unsigned int const n_agglomerates =
         ptree.get<unsigned int>("n_agglomerates");
 

--- a/include/mfmg/common/hierarchy.hpp
+++ b/include/mfmg/common/hierarchy.hpp
@@ -45,6 +45,18 @@ create_hierarchy_helpers(std::shared_ptr<MeshEvaluator const> evaluator)
     else
       ASSERT_THROW_NOT_IMPLEMENTED();
   }
+  else if (evaluator_type == "DealIIMatrixFreeMeshEvaluator")
+  {
+    int const dim = evaluator->get_dim();
+    if (dim == 2)
+      hierarchy_helpers.reset(
+          new DealIIMatrixFreeHierarchyHelpers<2, VectorType>());
+    else if (dim == 3)
+      hierarchy_helpers.reset(
+          new DealIIMatrixFreeHierarchyHelpers<3, VectorType>());
+    else
+      ASSERT_THROW_NOT_IMPLEMENTED();
+  }
   else if (evaluator_type == "CudaMeshEvaluator")
   {
     int const dim = evaluator->get_dim();

--- a/include/mfmg/common/hierarchy.hpp
+++ b/include/mfmg/common/hierarchy.hpp
@@ -20,6 +20,7 @@
 #include <mfmg/cuda/cuda_matrix_operator.cuh>
 #include <mfmg/cuda/cuda_mesh_evaluator.cuh>
 #include <mfmg/dealii/dealii_hierarchy_helpers.hpp>
+#include <mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 

--- a/include/mfmg/common/operator.hpp
+++ b/include/mfmg/common/operator.hpp
@@ -23,6 +23,8 @@ public:
   using operator_type = Operator<VectorType>;
   using vector_type = VectorType;
 
+  virtual ~Operator() = default;
+
   virtual void apply(vector_type const &x, vector_type &y) const = 0;
 
   virtual std::shared_ptr<operator_type> transpose() const = 0;

--- a/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
+++ b/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
@@ -22,12 +22,12 @@ class DealIIHierarchyHelpers : public HierarchyHelpers<VectorType>
 public:
   using vector_type = VectorType;
 
-  std::shared_ptr<Operator<vector_type>> get_global_operator(
-      std::shared_ptr<MeshEvaluator> mesh_evaluator) override final;
+  std::shared_ptr<Operator<vector_type>>
+  get_global_operator(std::shared_ptr<MeshEvaluator> mesh_evaluator) override;
 
   std::shared_ptr<Operator<vector_type>> build_restrictor(
       MPI_Comm comm, std::shared_ptr<MeshEvaluator> mesh_evaluator,
-      std::shared_ptr<boost::property_tree::ptree const> params) override final;
+      std::shared_ptr<boost::property_tree::ptree const> params) override;
 
   std::shared_ptr<Smoother<vector_type>> build_smoother(
       std::shared_ptr<Operator<vector_type> const> op,

--- a/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
+++ b/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
@@ -37,7 +37,7 @@ public:
       std::shared_ptr<Operator<vector_type> const> op,
       std::shared_ptr<boost::property_tree::ptree const> params) override final;
 
-private:
+protected:
   std::shared_ptr<Operator<vector_type>> _global_operator;
 };
 } // namespace mfmg

--- a/include/mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp
@@ -1,0 +1,35 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_MATRIX_FREE_HIERARCHY_HELPERS_HPP
+#define MFMG_DEALII_MATRIX_FREE_HIERARCHY_HELPERS_HPP
+
+#include <mfmg/dealii/dealii_hierarchy_helpers.hpp>
+
+namespace mfmg
+{
+template <int dim, typename VectorType>
+class DealIIMatrixFreeHierarchyHelpers
+    : public DealIIHierarchyHelpers<dim, VectorType>
+{
+public:
+  using vector_type = VectorType;
+
+  std::shared_ptr<Operator<vector_type>> get_global_operator(
+      std::shared_ptr<MeshEvaluator> mesh_evaluator) override final;
+
+  std::shared_ptr<Operator<vector_type>> build_restrictor(
+      MPI_Comm comm, std::shared_ptr<MeshEvaluator> mesh_evaluator,
+      std::shared_ptr<boost::property_tree::ptree const> params) override final;
+};
+} // namespace mfmg
+
+#endif

--- a/include/mfmg/dealii/dealii_matrix_free_operator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_operator.hpp
@@ -12,7 +12,7 @@
 #ifndef MFMG_DEALII_MATRIX_FREE_OPERATOR_HPP
 #define MFMG_DEALII_MATRIX_FREE_OPERATOR_HPP
 
-#include <mfmg/dealii_trilinos_matrix_operator.hpp>
+#include <mfmg/dealii/dealii_trilinos_matrix_operator.hpp>
 
 namespace mfmg
 {

--- a/include/mfmg/dealii/dealii_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_mesh_evaluator.hpp
@@ -25,8 +25,10 @@ template <int dim>
 class DealIIMeshEvaluator : public MeshEvaluator
 {
 public:
-  DealIIMeshEvaluator(dealii::DoFHandler<dim> &dof_handler,
-                      dealii::AffineConstraints<double> &constraints);
+  DealIIMeshEvaluator(
+      dealii::DoFHandler<dim> &dof_handler,
+      dealii::AffineConstraints<double> &constraints,
+      std::string const &mesh_evaluator_type = "DealIIMeshEvaluator");
 
   int get_dim() const override final;
 
@@ -64,6 +66,7 @@ public:
 protected:
   dealii::DoFHandler<dim> &_dof_handler;
   dealii::AffineConstraints<double> &_constraints;
+  std::string const _mesh_evaluator_type;
 };
 } // namespace mfmg
 

--- a/include/mfmg/dealii/dealii_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_mesh_evaluator.hpp
@@ -25,10 +25,9 @@ template <int dim>
 class DealIIMeshEvaluator : public MeshEvaluator
 {
 public:
-  DealIIMeshEvaluator(
-      dealii::DoFHandler<dim> &dof_handler,
-      dealii::AffineConstraints<double> &constraints,
-      std::string const &mesh_evaluator_type = "DealIIMeshEvaluator");
+  DealIIMeshEvaluator(dealii::DoFHandler<dim> &dof_handler,
+                      dealii::AffineConstraints<double> &constraints,
+                      std::string mesh_evaluator_type = "DealIIMeshEvaluator");
 
   int get_dim() const override final;
 

--- a/source/dealii/CMakeLists.txt
+++ b/source/dealii/CMakeLists.txt
@@ -7,6 +7,8 @@ SET(MFMG_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_smoother.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_solver.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_trilinos_matrix_operator.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dealii_matrix_free_operator.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dealii_matrix_free_hierarchy_helpers.cc
   )
 
 SET(MFMG_SOURCES ${MFMG_SOURCES} PARENT_SCOPE)

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -1,0 +1,92 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/common/instantiation.hpp>
+#include <mfmg/common/operator.hpp>
+#include <mfmg/dealii/amge_host.hpp>
+#include <mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp>
+#include <mfmg/dealii/dealii_matrix_free_operator.hpp>
+#include <mfmg/dealii/dealii_mesh_evaluator.hpp>
+#include <mfmg/dealii/dealii_smoother.hpp>
+#include <mfmg/dealii/dealii_trilinos_matrix_operator.hpp>
+
+namespace mfmg
+{
+// copy/paste from DealIIMatrixFreeHierarchyHelpers::get_global_operator()
+// only change is _global_operator.reset()
+template <int dim, typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::get_global_operator(
+    std::shared_ptr<MeshEvaluator> mesh_evaluator)
+{
+  if (this->_global_operator == nullptr)
+  {
+    // Downcast to DealIIMeshEvaluator
+    auto dealii_mesh_evaluator =
+        std::dynamic_pointer_cast<DealIIMeshEvaluator<dim>>(mesh_evaluator);
+
+    auto system_matrix =
+        std::make_shared<dealii::TrilinosWrappers::SparseMatrix>();
+
+    // Call user function to fill in the system matrix
+    dealii_mesh_evaluator->evaluate_global(
+        dealii_mesh_evaluator->get_dof_handler(),
+        dealii_mesh_evaluator->get_constraints(), *system_matrix);
+
+    this->_global_operator.reset(
+        new DealIIMatrixFreeOperator<VectorType>(system_matrix));
+  }
+
+  return this->_global_operator;
+}
+
+// copy/paste from DealIIHierarchyHelpers::build_restrictor()
+template <int dim, typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
+    MPI_Comm comm, std::shared_ptr<MeshEvaluator> mesh_evaluator,
+    std::shared_ptr<boost::property_tree::ptree const> params)
+{
+  // Downcast to DealIIMeshEvaluator
+  auto dealii_mesh_evaluator =
+      std::dynamic_pointer_cast<DealIIMeshEvaluator<dim>>(mesh_evaluator);
+
+  auto eigensolver_params = params->get_child("eigensolver");
+  AMGe_host<dim, DealIIMeshEvaluator<dim>, VectorType> amge(
+      comm, dealii_mesh_evaluator->get_dof_handler(),
+      eigensolver_params.get("type", "arpack"));
+
+  auto agglomerate_params = params->get_child("agglomeration");
+  int n_eigenvectors = eigensolver_params.get("number of eigenvectors", 1);
+  double tolerance = eigensolver_params.get("tolerance", 1e-14);
+
+  auto restrictor_matrix =
+      std::make_shared<dealii::TrilinosWrappers::SparseMatrix>();
+  auto global_operator = get_global_operator(mesh_evaluator);
+  auto matrix_free_global_operator =
+      std::dynamic_pointer_cast<DealIIMatrixFreeOperator<VectorType>>(
+          global_operator);
+  // ughhh
+  auto system_sparse_matrix = matrix_free_global_operator->get_matrix();
+  // why do we pass system matrix to amge?
+  amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
+                        *dealii_mesh_evaluator, *system_sparse_matrix,
+                        *restrictor_matrix);
+
+  std::shared_ptr<Operator<VectorType>> op(
+      new DealIITrilinosMatrixOperator<VectorType>(restrictor_matrix));
+
+  return op;
+}
+} // namespace mfmg
+
+// Explicit Instantiation
+INSTANTIATE_DIM_VECTORTYPE(TUPLE(DealIIMatrixFreeHierarchyHelpers))

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -49,6 +49,7 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::get_global_operator(
 }
 
 // copy/paste from DealIIHierarchyHelpers::build_restrictor()
+// only change is downcast of global_operator
 template <int dim, typename VectorType>
 std::shared_ptr<Operator<VectorType>>
 DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -75,9 +75,9 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
   auto matrix_free_global_operator =
       std::dynamic_pointer_cast<DealIIMatrixFreeOperator<VectorType>>(
           global_operator);
-  // ughhh
+  // FIXME only the diagonal entries are actually needed to compute the
+  // restrictor. See ORNL-CEES/mfmg#97
   auto system_sparse_matrix = matrix_free_global_operator->get_matrix();
-  // why do we pass system matrix to amge?
   amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
                         *dealii_mesh_evaluator, *system_sparse_matrix,
                         *restrictor_matrix);

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/dealii_matrix_free_operator.hpp>
+#include <mfmg/dealii/dealii_matrix_free_operator.hpp>
 
 #include <deal.II/lac/la_parallel_vector.h>
 

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -40,7 +40,9 @@ extract_row(dealii::TrilinosWrappers::SparseMatrix const &matrix,
 
   dealii::IndexSet ghost_indices(matrix.locally_owned_domain_indices().size());
   for (int k = 0; k < num_entries; ++k)
+  {
     ghost_indices.add_index(matrix.trilinos_matrix().GCID(local_indices[k]));
+  }
   ghost_indices.compress();
   dealii::LinearAlgebra::distributed::Vector<double> ghosted_vector(
       matrix.locally_owned_domain_indices(), ghost_indices,
@@ -100,7 +102,9 @@ void matrix_transpose_matrix_multiply(
       {
         auto const value = dst[i];
         if (std::abs(value) > 1e-14) // is that an appropriate epsilon?
+        {
           C.set(i, j, value);
+        }
       }
     }
   }

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
+#include <mfmg/common/exceptions.hpp>
 #include <mfmg/common/instantiation.hpp>
 #include <mfmg/dealii/dealii_matrix_free_operator.hpp>
 

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -126,10 +126,11 @@ DealIIMatrixFreeOperator<VectorType>::multiply(
 {
   // Downcast to TrilinosMatrixOperator
   auto downcast_b =
-      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(b);
+      std::dynamic_pointer_cast<DealIITrilinosMatrixOperator<VectorType> const>(
+          b);
 
   auto a_mat = this->get_matrix();
-  auto b_mat = downcast_b.get_matrix();
+  auto b_mat = downcast_b->get_matrix();
 
   auto c_mat = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>();
   a_mat->mmult(*c_mat, *b_mat);
@@ -144,10 +145,11 @@ DealIIMatrixFreeOperator<VectorType>::multiply_transpose(
 {
   // Downcast to TrilinosMatrixOperator
   auto downcast_b =
-      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(b);
+      std::dynamic_pointer_cast<DealIITrilinosMatrixOperator<VectorType> const>(
+          b);
 
   auto a_mat = this->get_matrix();
-  auto b_mat = downcast_b.get_matrix();
+  auto b_mat = downcast_b->get_matrix();
 
   auto c_mat = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>(
       a_mat->locally_owned_range_indices(),

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
+#include <mfmg/common/instantiation.hpp>
 #include <mfmg/dealii/dealii_matrix_free_operator.hpp>
 
 #include <deal.II/lac/la_parallel_vector.h>
@@ -154,5 +155,4 @@ DealIIMatrixFreeOperator<VectorType>::multiply_transpose(
 } // namespace mfmg
 
 // Explicit Instantiation
-template class mfmg::DealIIMatrixFreeOperator<
-    dealii::LinearAlgebra::distributed::Vector<double>>;
+INSTANTIATE_VECTORTYPE(TUPLE(DealIIMatrixFreeOperator))

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -108,48 +108,48 @@ void matrix_transpose_matrix_multiply(
 
 template <typename VectorType>
 DealIIMatrixFreeOperator<VectorType>::DealIIMatrixFreeOperator(
-    std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> matrix)
-    : DealIITrilinosMatrixOperator<VectorType>(matrix)
+    std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> sparse_matrix)
+    : DealIITrilinosMatrixOperator<VectorType>(sparse_matrix)
 {
 }
 
 template <typename VectorType>
 std::shared_ptr<Operator<VectorType>>
 DealIIMatrixFreeOperator<VectorType>::multiply(
-    std::shared_ptr<Operator<VectorType> const> operator_b) const
+    std::shared_ptr<Operator<VectorType> const> b) const
 {
   // Downcast to TrilinosMatrixOperator
-  auto downcast_operator_b =
-      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(operator_b);
+  auto downcast_b =
+      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(b);
 
-  auto a = this->get_matrix();
-  auto b = downcast_operator_b.get_matrix();
+  auto a_mat = this->get_matrix();
+  auto b_mat = downcast_b.get_matrix();
 
-  auto c = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>();
-  a->mmult(*c, *b);
+  auto c_mat = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>();
+  a_mat->mmult(*c_mat, *b_mat);
 
-  return std::make_shared<DealIIMatrixFreeOperator<VectorType>>(c);
+  return std::make_shared<DealIIMatrixFreeOperator<VectorType>>(c_mat);
 }
 
 template <typename VectorType>
 std::shared_ptr<Operator<VectorType>>
 DealIIMatrixFreeOperator<VectorType>::multiply_transpose(
-    std::shared_ptr<Operator<VectorType> const> operator_b) const
+    std::shared_ptr<Operator<VectorType> const> b) const
 {
   // Downcast to TrilinosMatrixOperator
-  auto downcast_operator_b =
-      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(operator_b);
+  auto downcast_b =
+      static_cast<DealIITrilinosMatrixOperator<VectorType> const &>(b);
 
-  auto a = this->get_matrix();
-  auto b = downcast_operator_b.get_matrix();
+  auto a_mat = this->get_matrix();
+  auto b_mat = downcast_b.get_matrix();
 
-  auto c = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>(
-      a->locally_owned_range_indices(), b->locally_owned_range_indices(),
-      a->get_mpi_communicator());
+  auto c_mat = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>(
+      a_mat->locally_owned_range_indices(),
+      b_mat->locally_owned_range_indices(), a_mat->get_mpi_communicator());
 
-  matrix_transpose_matrix_multiply(*c, *b, *a);
+  matrix_transpose_matrix_multiply(*c_mat, *b_mat, *a_mat);
 
-  return std::make_shared<DealIIMatrixFreeOperator<VectorType>>(c);
+  return std::make_shared<DealIIMatrixFreeOperator<VectorType>>(c_mat);
 }
 } // namespace mfmg
 

--- a/source/dealii/dealii_mesh_evaluator.cc
+++ b/source/dealii/dealii_mesh_evaluator.cc
@@ -46,7 +46,9 @@ void DealIIMeshEvaluator<dim>::set_initial_guess(
   std::default_random_engine generator;
   std::uniform_real_distribution<double> distribution(0., 1.);
   for (unsigned int i = 0; i < n; ++i)
+  {
     x[i] = (!constraints.is_constrained(i) ? distribution(generator) : 0.);
+  }
 }
 
 template <int dim>

--- a/source/dealii/dealii_mesh_evaluator.cc
+++ b/source/dealii/dealii_mesh_evaluator.cc
@@ -21,9 +21,9 @@ template <int dim>
 DealIIMeshEvaluator<dim>::DealIIMeshEvaluator(
     dealii::DoFHandler<dim> &dof_handler,
     dealii::AffineConstraints<double> &constraints,
-    std::string const &mesh_evaluator_type)
+    std::string mesh_evaluator_type)
     : _dof_handler(dof_handler), _constraints(constraints),
-      _mesh_evaluator_type(mesh_evaluator_type)
+      _mesh_evaluator_type(std::move(mesh_evaluator_type))
 {
   std::vector<std::string> const valid_mesh_evaluator_types = {
       "DealIIMeshEvaluator", "DealIIMatrixFreeMeshEvaluator"};

--- a/source/dealii/dealii_mesh_evaluator.cc
+++ b/source/dealii/dealii_mesh_evaluator.cc
@@ -12,6 +12,9 @@
 #include <mfmg/common/instantiation.hpp>
 #include <mfmg/dealii/dealii_mesh_evaluator.hpp>
 
+#include <algorithm>
+#include <vector>
+
 namespace mfmg
 {
 template <int dim>
@@ -22,6 +25,14 @@ DealIIMeshEvaluator<dim>::DealIIMeshEvaluator(
     : _dof_handler(dof_handler), _constraints(constraints),
       _mesh_evaluator_type(mesh_evaluator_type)
 {
+  std::vector<std::string> const valid_mesh_evaluator_types = {
+      "DealIIMeshEvaluator", "DealIIMatrixFreeMeshEvaluator"};
+  ASSERT(std::find(std::begin(valid_mesh_evaluator_types),
+                   std::end(valid_mesh_evaluator_types),
+                   _mesh_evaluator_type) !=
+             std::end(valid_mesh_evaluator_types),
+         "mesh_evaluator_type string argument passed to DealIIMeshEvaluator "
+         "constructor is not valid");
 }
 
 template <int dim>

--- a/source/dealii/dealii_mesh_evaluator.cc
+++ b/source/dealii/dealii_mesh_evaluator.cc
@@ -17,8 +17,10 @@ namespace mfmg
 template <int dim>
 DealIIMeshEvaluator<dim>::DealIIMeshEvaluator(
     dealii::DoFHandler<dim> &dof_handler,
-    dealii::AffineConstraints<double> &constraints)
-    : _dof_handler(dof_handler), _constraints(constraints)
+    dealii::AffineConstraints<double> &constraints,
+    std::string const &mesh_evaluator_type)
+    : _dof_handler(dof_handler), _constraints(constraints),
+      _mesh_evaluator_type(mesh_evaluator_type)
 {
 }
 
@@ -31,7 +33,7 @@ int DealIIMeshEvaluator<dim>::get_dim() const
 template <int dim>
 std::string DealIIMeshEvaluator<dim>::get_mesh_evaluator_type() const
 {
-  return "DealIIMeshEvaluator";
+  return _mesh_evaluator_type;
 }
 
 template <int dim>

--- a/source/dealii/dealii_mesh_evaluator.cc
+++ b/source/dealii/dealii_mesh_evaluator.cc
@@ -44,8 +44,7 @@ void DealIIMeshEvaluator<dim>::set_initial_guess(
   std::default_random_engine generator;
   std::uniform_real_distribution<double> distribution(0., 1.);
   for (unsigned int i = 0; i < n; ++i)
-    x[i] =
-        (constraints.is_constrained(i) == false ? distribution(generator) : 0.);
+    x[i] = (!constraints.is_constrained(i) ? distribution(generator) : 0.);
 }
 
 template <int dim>

--- a/source/dealii/dealii_trilinos_matrix_operator.cc
+++ b/source/dealii/dealii_trilinos_matrix_operator.cc
@@ -72,25 +72,25 @@ DealIITrilinosMatrixOperator<VectorType>::multiply(
 template <typename VectorType>
 std::shared_ptr<Operator<VectorType>>
 DealIITrilinosMatrixOperator<VectorType>::multiply_transpose(
-    std::shared_ptr<Operator<VectorType> const> operator_b) const
+    std::shared_ptr<Operator<VectorType> const> b) const
 {
   // Downcast to TrilinosMatrixOperator
-  auto downcast_operator_b =
+  auto downcast_b =
       std::dynamic_pointer_cast<DealIITrilinosMatrixOperator<VectorType> const>(
-          operator_b);
-  auto a = this->get_matrix();
-  auto b = downcast_operator_b->get_matrix();
-  auto c = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>(
-      a->locally_owned_range_indices(), b->locally_owned_range_indices(),
-      a->get_mpi_communicator());
+          b);
+  auto a_mat = this->get_matrix();
+  auto b_mat = downcast_b->get_matrix();
+  auto c_mat = std::make_shared<dealii::TrilinosWrappers::SparseMatrix>(
+      a_mat->locally_owned_range_indices(),
+      b_mat->locally_owned_range_indices(), a_mat->get_mpi_communicator());
   int error_code = EpetraExt::MatrixMatrix::Multiply(
-      a->trilinos_matrix(), false, b->trilinos_matrix(), true,
-      const_cast<Epetra_CrsMatrix &>(c->trilinos_matrix()));
+      a_mat->trilinos_matrix(), false, b_mat->trilinos_matrix(), true,
+      const_cast<Epetra_CrsMatrix &>(c_mat->trilinos_matrix()));
   ASSERT(error_code == 0, "EpetraExt::MatrixMatrix::Multiply() returned "
                           "non-zero error code in "
                           "DealIITrilinosMatrixOperator::multiply_transpose()");
 
-  return std::make_shared<DealIITrilinosMatrixOperator<VectorType>>(c);
+  return std::make_shared<DealIITrilinosMatrixOperator<VectorType>>(c_mat);
 }
 
 template <typename VectorType>

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -36,8 +36,11 @@ void main_(std::shared_ptr<boost::property_tree::ptree> params)
   for (auto const index : locally_owned_dofs)
     solution[index] = distribution(generator);
 
-  std::shared_ptr<MeshEvaluator> evaluator(new TestMeshEvaluator<dim>(
-      laplace._dof_handler, laplace._constraints, a, material_property));
+  std::string const mesh_evaluator_type = "DealIIMeshEvaluator";
+
+  std::shared_ptr<MeshEvaluator> evaluator(
+      new TestMeshEvaluator<dim>(laplace._dof_handler, laplace._constraints, a,
+                                 material_property, mesh_evaluator_type));
   mfmg::Hierarchy<DVector> hierarchy(comm, evaluator, params);
 
   pcout << "Grid complexity    : " << hierarchy.grid_complexity() << std::endl;

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -206,11 +206,8 @@ BOOST_DATA_TEST_CASE(hierarchy_3d,
   }
 }
 
-// There is a problem with Zoltan where the second time it is called (with the
-// same input) the partitioning is different than the first time. This looks
-// like a problem from Zoltan (we only use it through deal.II and the code looks
-// fine), so we run the Zoltan test only once.
-BOOST_AUTO_TEST_CASE(zoltan)
+BOOST_DATA_TEST_CASE(zoltan, bdata::make(mesh_evaluator_types),
+                     mesh_evaluator_type)
 {
   if (dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1)
   {
@@ -219,7 +216,7 @@ BOOST_AUTO_TEST_CASE(zoltan)
     auto params = std::make_shared<boost::property_tree::ptree>();
     boost::property_tree::info_parser::read_info("hierarchy_input.info",
                                                  *params);
-    params->put("mesh_evaluator_type", "DealIIMeshEvaluator");
+    params->put("mesh_evaluator_type", mesh_evaluator_type);
 
     params->put("agglomeration.partitioner", "zoltan");
     params->put("agglomeration.n_agglomerates", 4);

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -206,8 +206,11 @@ BOOST_DATA_TEST_CASE(hierarchy_3d,
   }
 }
 
-BOOST_DATA_TEST_CASE(zoltan, bdata::make(mesh_evaluator_types),
-                     mesh_evaluator_type)
+// There is a problem with Zoltan where the second time it is called (with the
+// same input) the partitioning is different than the first time. This looks
+// like a problem from Zoltan (we only use it through deal.II and the code looks
+// fine), so we run the Zoltan test only once.
+BOOST_AUTO_TEST_CASE(zoltan)
 {
   if (dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1)
   {
@@ -216,7 +219,7 @@ BOOST_DATA_TEST_CASE(zoltan, bdata::make(mesh_evaluator_types),
     auto params = std::make_shared<boost::property_tree::ptree>();
     boost::property_tree::info_parser::read_info("hierarchy_input.info",
                                                  *params);
-    params->put("mesh_evaluator_type", mesh_evaluator_type);
+    params->put("mesh_evaluator_type", "DealIIMeshEvaluator");
 
     params->put("agglomeration.partitioner", "zoltan");
     params->put("agglomeration.n_agglomerates", 4);

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -206,7 +206,8 @@ BOOST_DATA_TEST_CASE(hierarchy_3d,
   }
 }
 
-BOOST_AUTO_TEST_CASE(zoltan)
+BOOST_DATA_TEST_CASE(zoltan, bdata::make(mesh_evaluator_types),
+                     mesh_evaluator_type)
 {
   if (dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1)
   {
@@ -215,6 +216,7 @@ BOOST_AUTO_TEST_CASE(zoltan)
     auto params = std::make_shared<boost::property_tree::ptree>();
     boost::property_tree::info_parser::read_info("hierarchy_input.info",
                                                  *params);
+    params->put("mesh_evaluator_type", mesh_evaluator_type);
 
     params->put("agglomeration.partitioner", "zoltan");
     params->put("agglomeration.n_agglomerates", 4);

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -140,8 +140,10 @@ public:
   TestMeshEvaluator(dealii::DoFHandler<dim> &dof_handler,
                     dealii::AffineConstraints<double> &constraints,
                     dealii::TrilinosWrappers::SparseMatrix const &matrix,
-                    std::shared_ptr<dealii::Function<dim>> material_property)
-      : mfmg::DealIIMeshEvaluator<dim>(dof_handler, constraints),
+                    std::shared_ptr<dealii::Function<dim>> material_property,
+                    std::string mesh_evaluator_type)
+      : mfmg::DealIIMeshEvaluator<dim>(dof_handler, constraints,
+                                       std::move(mesh_evaluator_type)),
         _matrix(matrix), _material_property(material_property)
   {
   }


### PR DESCRIPTION
Closes #91 

~~Drop e9116f5 before merging the changes.~~ Done!
~~Probably should define another evaluator type name for it and test both for the legacy and the new matrix free types.~~ Added `mesh_evaluator_type` string argument with default value `"DealIIMeshEvaluator"` instead