### PR TITLE
Remove explicit prolongator construction

### DIFF
--- a/include/mfmg/common/level.hpp
+++ b/include/mfmg/common/level.hpp
@@ -36,11 +36,6 @@ public:
     return _restrictor;
   }
 
-  std::shared_ptr<operator_type const> get_prolongator() const
-  {
-    return _prolongator;
-  }
-
   std::shared_ptr<Smoother<vector_type> const> get_smoother() const
   {
     return _smoother;
@@ -58,11 +53,6 @@ public:
     _restrictor = r;
   }
 
-  void set_prolongator(std::shared_ptr<operator_type const> p)
-  {
-    _prolongator = p;
-  }
-
   void set_smoother(std::shared_ptr<Smoother<vector_type> const> s)
   {
     _smoother = s;
@@ -70,8 +60,17 @@ public:
 
   void set_solver(std::shared_ptr<Solver<vector_type> const> s) { _solver = s; }
 
+  std::shared_ptr<vector_type> build_vector() const
+  {
+    auto a = get_operator();
+    ASSERT(
+        a != nullptr,
+        "build_vector() can only be called after the level operator was set.");
+    return a->build_domain_vector();
+  }
+
 private:
-  std::shared_ptr<operator_type const> _operator, _prolongator, _restrictor;
+  std::shared_ptr<operator_type const> _operator, _restrictor;
   std::shared_ptr<Smoother<vector_type> const> _smoother;
   std::shared_ptr<Solver<vector_type> const> _solver;
 };

--- a/include/mfmg/common/operator.hpp
+++ b/include/mfmg/common/operator.hpp
@@ -16,6 +16,12 @@
 
 namespace mfmg
 {
+enum class OperatorMode
+{
+  NO_TRANS,
+  TRANS
+};
+
 template <typename VectorType>
 class Operator
 {
@@ -25,7 +31,8 @@ public:
 
   virtual ~Operator() = default;
 
-  virtual void apply(vector_type const &x, vector_type &y) const = 0;
+  virtual void apply(vector_type const &x, vector_type &y,
+                     OperatorMode mode = OperatorMode::NO_TRANS) const = 0;
 
   virtual std::shared_ptr<operator_type> transpose() const = 0;
 

--- a/include/mfmg/cuda/cuda_matrix_operator.cuh
+++ b/include/mfmg/cuda/cuda_matrix_operator.cuh
@@ -29,7 +29,8 @@ public:
   CudaMatrixOperator(
       std::shared_ptr<SparseMatrixDevice<value_type>> sparse_matrix);
 
-  void apply(vector_type const &x, vector_type &y) const override final;
+  void apply(vector_type const &x, vector_type &y,
+             OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 
   std::shared_ptr<Operator<VectorType>> transpose() const override final;
 
@@ -50,7 +51,8 @@ public:
   std::shared_ptr<SparseMatrixDevice<value_type>> get_matrix() const;
 
 private:
-  std::shared_ptr<SparseMatrixDevice<value_type>> _matrix;
+  mutable std::shared_ptr<SparseMatrixDevice<value_type>> _matrix;
+  mutable std::shared_ptr<SparseMatrixDevice<value_type>> _transposed_matrix;
 };
 } // namespace mfmg
 

--- a/include/mfmg/dealii/dealii_matrix_operator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_operator.hpp
@@ -31,7 +31,8 @@ public:
       std::shared_ptr<dealii::SparseMatrix<typename VectorType::value_type>>
           sparse_matrix);
 
-  void apply(vector_type const &x, vector_type &y) const override final;
+  void apply(vector_type const &x, vector_type &y,
+             OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 
   std::shared_ptr<Operator<VectorType>> multiply_transpose(
       std::shared_ptr<Operator<VectorType> const> b) const override final;

--- a/include/mfmg/dealii/dealii_trilinos_matrix_operator.hpp
+++ b/include/mfmg/dealii/dealii_trilinos_matrix_operator.hpp
@@ -27,7 +27,8 @@ public:
   DealIITrilinosMatrixOperator(
       std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> sparse_matrix);
 
-  void apply(vector_type const &x, vector_type &y) const override final;
+  void apply(vector_type const &x, vector_type &y,
+             OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 
   std::shared_ptr<Operator<VectorType>> transpose() const override final;
 

--- a/source/dealii/dealii_matrix_operator.cc
+++ b/source/dealii/dealii_matrix_operator.cc
@@ -31,10 +31,11 @@ DealIIMatrixOperator<VectorType>::DealIIMatrixOperator(
 }
 
 template <typename VectorType>
-void DealIIMatrixOperator<VectorType>::apply(VectorType const &x,
-                                             VectorType &y) const
+void DealIIMatrixOperator<VectorType>::apply(VectorType const &x, VectorType &y,
+                                             OperatorMode mode) const
 {
-  _sparse_matrix->vmult(y, x);
+  (mode == OperatorMode::NO_TRANS ? _sparse_matrix->vmult(y, x)
+                                  : _sparse_matrix->Tvmult(y, x));
 }
 
 template <typename VectorType>

--- a/source/dealii/dealii_trilinos_matrix_operator.cc
+++ b/source/dealii/dealii_trilinos_matrix_operator.cc
@@ -27,9 +27,11 @@ DealIITrilinosMatrixOperator<VectorType>::DealIITrilinosMatrixOperator(
 
 template <typename VectorType>
 void DealIITrilinosMatrixOperator<VectorType>::apply(VectorType const &x,
-                                                     VectorType &y) const
+                                                     VectorType &y,
+                                                     OperatorMode mode) const
 {
-  _sparse_matrix->vmult(y, x);
+  (mode == OperatorMode::NO_TRANS ? _sparse_matrix->vmult(y, x)
+                                  : _sparse_matrix->Tvmult(y, x));
 }
 
 template <typename VectorType>


### PR DESCRIPTION
This PR adds support for `apply()` in transpose mode, and removes prolongator from the hierarchy, replacing it by action of restrictor in transpose mode.

As we don't have a proper support for transpose action in device sparse matrices, I chose to workaround that by using the implemented `transpose()` call of `CudaMatrixOperator`. That class now caches the matrix transpose when needed. I am not sure how to avoid `mutable` class variables, though, and open to suggestions.