### PR TITLE
Use boundary on the agglomerates

### DIFF
--- a/tests/laplace.hpp
+++ b/tests/laplace.hpp
@@ -109,7 +109,7 @@ void Laplace<dim, VectorType>::setup_system(
   }
 
   if (ptree.get("distort_random", false))
-    dealii::GridTools::distort_random(0.2, _triangulation);
+    dealii::GridTools::distort_random(0.1, _triangulation);
 
   _dof_handler.distribute_dofs(_fe);
 

--- a/tests/laplace.hpp
+++ b/tests/laplace.hpp
@@ -271,7 +271,8 @@ void Laplace<dim, VectorType>::output_results() const
     for (unsigned int i = 0; i < comm_size; ++i)
       filenames.push_back("solution-" + std::to_string(i) + "-" +
                           std::to_string(comm_size) + ".vtu");
-    std::ofstream master_output("solution.pvtu");
+    std::ofstream master_output("solution-" + std::to_string(comm_size) +
+                                ".pvtu");
     data_out.write_pvtu_record(master_output, filenames);
   }
   MPI_Barrier(_comm);

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -195,23 +195,22 @@ BOOST_DATA_TEST_CASE(
     // break the code
     std::map<std::tuple<std::string, bool, std::string>, double> ref_solution;
     ref_solution[std::make_tuple("hyper_cube", false, "None")] =
-        is_matrix_free ? 0.1606059764 : 0.0425111106;
+        is_matrix_free ? 0.1482630509 : 0.0491724046;
     ref_solution[std::make_tuple("hyper_cube", false,
                                  "Reverse Cuthill_McKee")] =
-        is_matrix_free ? 0.1606059764 : 0.0425111106;
+        is_matrix_free ? 0.1482630509 : 0.0491724046;
     ref_solution[std::make_tuple("hyper_cube", true, "None")] =
-        is_matrix_free ? 0.1617008736 : 0.0398672044;
+        is_matrix_free ? 0.1575262224 : 0.0488984875;
     ref_solution[std::make_tuple("hyper_cube", true, "Reverse Cuthill_McKee")] =
-        is_matrix_free ? 0.1617008736 : 0.0398672044;
+        is_matrix_free ? 0.1575262224 : 0.0488984875;
     ref_solution[std::make_tuple("hyper_ball", false, "None")] =
-        is_matrix_free ? 0.3157576610 : 0.1303442282;
-    ref_solution[std::make_tuple("hyper_ball", false,
-                                 "Reverse Cuthill_McKee")] =
-        is_matrix_free ? 0.3157576610 : 0.1303442282;
+        ref_solution[std::make_tuple("hyper_ball", false,
+                                     "Reverse Cuthill_McKee")] =
+            is_matrix_free ? 0.3022004744 : 0.1146629782;
     ref_solution[std::make_tuple("hyper_ball", true, "None")] =
-        is_matrix_free ? 0.3253460593 : 0.1431096468;
+        is_matrix_free ? 0.2977841482 : 0.1024334788;
     ref_solution[std::make_tuple("hyper_ball", true, "Reverse Cuthill_McKee")] =
-        is_matrix_free ? 0.3253460593 : 0.1431096468;
+        is_matrix_free ? 0.2977841482 : 0.1024334788;
 
     if (mesh == std::string("hyper_cube"))
       BOOST_TEST(
@@ -249,7 +248,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(zoltan, MeshEvaluator, mesh_evaluator_types)
 
     // This is a gold standard test. Not the greatest but it makes sure we don't
     // break the code
-    double const ref_solution = is_matrix_free ? 0.918915720 : 0.903284598;
+    double const ref_solution = is_matrix_free ? 0.897494709 : 0.838850614;
     double const conv_rate = test<MeshEvaluator>(params);
     BOOST_TEST(conv_rate == ref_solution, tt::tolerance(1e-6));
   }

--- a/tests/test_hierarchy_device.cu
+++ b/tests/test_hierarchy_device.cu
@@ -191,6 +191,8 @@ public:
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+    dealii::VectorTools::interpolate_boundary_values(
+        dof_handler, 1, dealii::Functions::ZeroFunction<dim>(), constraints);
     constraints.close();
 
     // Build the system sparsity pattern and reinitialize the system sparse

--- a/tests/test_hierarchy_device.cu
+++ b/tests/test_hierarchy_device.cu
@@ -347,21 +347,21 @@ BOOST_AUTO_TEST_CASE(hierarchy_3d)
     // don't break the code
     std::map<std::tuple<std::string, bool, std::string>, double> ref_solution;
     ref_solution[std::make_tuple("hyper_cube", false, "None")] =
-        0.16193365416298541;
+        0.14933479171507894;
     ref_solution[std::make_tuple(
-        "hyper_cube", false, "Reverse Cuthill_McKee")] = 0.16193365416298544;
+        "hyper_cube", false, "Reverse Cuthill_McKee")] = 0.14933479171507894;
     ref_solution[std::make_tuple("hyper_cube", true, "None")] =
-        0.1486537142879813;
+        0.15334169107506268;
     ref_solution[std::make_tuple("hyper_cube", true, "Reverse Cuthill_McKee")] =
-        0.14865371428798133;
+        0.15334169107506268;
     ref_solution[std::make_tuple("hyper_ball", false, "None")] =
-        0.5708404747197412;
+        0.5953407021456707;
     ref_solution[std::make_tuple(
-        "hyper_ball", false, "Reverse Cuthill_McKee")] = 0.57084047471973909;
+        "hyper_ball", false, "Reverse Cuthill_McKee")] = 0.59534070214567336;
     ref_solution[std::make_tuple("hyper_ball", true, "None")] =
-        0.6601100828832337;
+        0.62020418011247469;
     ref_solution[std::make_tuple("hyper_ball", true, "Reverse Cuthill_McKee")] =
-        0.6601100828832337;
+        0.62020418011247469;
 
     for (auto mesh : {"hyper_cube", "hyper_ball"})
       for (auto distort_random : {false, true})

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -175,6 +175,8 @@ public:
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+    dealii::VectorTools::interpolate_boundary_values(
+        dof_handler, 1, dealii::Functions::ZeroFunction<dim>(), constraints);
     constraints.close();
 
     // Build the system sparsity pattern and reinitialize the system sparse

--- a/tests/test_laplace.cc
+++ b/tests/test_laplace.cc
@@ -108,7 +108,9 @@ BOOST_AUTO_TEST_CASE(laplace_2d)
       dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   if (rank == 0)
   {
-    BOOST_TEST(std::remove("solution.pvtu") == 0);
+    BOOST_TEST(
+        std::remove(
+            ("solution-" + std::to_string(world_size) + ".pvtu").c_str()) == 0);
     for (unsigned int i = 0; i < world_size; ++i)
       BOOST_TEST(std::remove(("solution-" + std::to_string(i) + "-" +
                               std::to_string(world_size) + ".vtu")

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -54,7 +54,7 @@ public:
   }
 };
 
-BOOST_AUTO_TEST_CASE(restriction_matrix)
+BOOST_AUTO_TEST_CASE(restriction_matrix, *utf::tolerance(1e-14))
 {
   unsigned int constexpr dim = 2;
 
@@ -230,6 +230,9 @@ public:
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+    // The test requires us not to put boundary conditions
+    // dealii::VectorTools::interpolate_boundary_values(
+    //     dof_handler, 1, dealii::Functions::ZeroFunction<dim>(), constraints);
     constraints.close();
 
     // Build the system sparsity pattern and reinitialize the system sparse


### PR DESCRIPTION
This PR add support for boundary on the agglomerates. With it, I can reproduce the result from the paper. Note that the convergence rate is sometimes better and sometimes worse. Also, I had to decrease the randomness of the mesh because the coarse matrix was too ill-conditioned for the direct solver. Trilinos would throw an error but scipy worked.