### PR TITLE
Use apply instead of vmult

### DIFF
--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -32,9 +32,8 @@ public:
 
   std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> get_matrix() const;
 
-  void
-  vmult(dealii::LinearAlgebra::distributed::Vector<double> &dst,
-        dealii::LinearAlgebra::distributed::Vector<double> const &src) const;
+  void apply(dealii::LinearAlgebra::distributed::Vector<double> const &src,
+             dealii::LinearAlgebra::distributed::Vector<double> &dst) const;
 
   std::shared_ptr<dealii::LinearAlgebra::distributed::Vector<double>>
   build_range_vector() const;

--- a/source/dealii/dealii_matrix_free_mesh_evaluator.cc
+++ b/source/dealii/dealii_matrix_free_mesh_evaluator.cc
@@ -43,9 +43,9 @@ DealIIMatrixFreeMeshEvaluator<dim>::get_matrix() const
 }
 
 template <int dim>
-void DealIIMatrixFreeMeshEvaluator<dim>::vmult(
-    dealii::LinearAlgebra::distributed::Vector<double> &dst,
-    dealii::LinearAlgebra::distributed::Vector<double> const &src) const
+void DealIIMatrixFreeMeshEvaluator<dim>::apply(
+    dealii::LinearAlgebra::distributed::Vector<double> const &src,
+    dealii::LinearAlgebra::distributed::Vector<double> &dst) const
 {
   _sparse_matrix->vmult(dst, src);
 }

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -148,10 +148,10 @@ void DealIIMatrixFreeOperator<VectorType>::vmult(VectorType &dst,
   _mesh_evaluator->get_dim() == 2
       ? std::dynamic_pointer_cast<DealIIMatrixFreeMeshEvaluator<2>>(
             _mesh_evaluator)
-            ->vmult(dst, src)
+            ->apply(src, dst)
       : std::dynamic_pointer_cast<DealIIMatrixFreeMeshEvaluator<3>>(
             _mesh_evaluator)
-            ->vmult(dst, src);
+            ->apply(src, dst);
 }
 
 template <typename VectorType>


### PR DESCRIPTION
We use `apply(src, dst)` instead of deal.II `vmult(dst, src)`