### PR TITLE
Move functions using deal.II to dealii_utils

### DIFF
--- a/include/mfmg/common/utils.hpp
+++ b/include/mfmg/common/utils.hpp
@@ -14,9 +14,6 @@
 
 #include <mfmg/common/exceptions.hpp>
 
-#include <deal.II/lac/trilinos_sparse_matrix.h>
-#include <deal.II/lac/trilinos_vector.h>
-
 #include <Teuchos_ParameterList.hpp>
 
 #include <boost/property_tree/ptree.hpp>
@@ -27,15 +24,6 @@
 
 namespace mfmg
 {
-
-void matrix_market_output_file(
-    const std::string &filename,
-    const dealii::TrilinosWrappers::SparseMatrix &matrix);
-
-void matrix_market_output_file(
-    const std::string &filename,
-    const dealii::TrilinosWrappers::MPI::Vector &vector);
-
 void ptree2plist(boost::property_tree::ptree const &ptree,
                  Teuchos::ParameterList &plist);
 

--- a/include/mfmg/dealii/dealii_utils.hpp
+++ b/include/mfmg/dealii/dealii_utils.hpp
@@ -1,0 +1,87 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#ifndef MFMG_DEALII_UTILS_H
+#define MFMG_DEALII_UTILS_H
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <string>
+
+namespace mfmg
+{
+dealii::LinearAlgebra::distributed::Vector<double>
+extract_row(dealii::TrilinosWrappers::SparseMatrix const &matrix,
+            dealii::types::global_dof_index global_j);
+
+// matrix_transpose_matrix_multiply(C, B, A) performs the matrix-matrix
+// multiplication with the transpose of B, i.e. C = A * B^T
+//
+// Note that it is different from deal.II's SparseMatrix::Tmmult(C, B) which
+// performs C = A^T * B
+template <typename Operator>
+void matrix_transpose_matrix_multiply(
+    dealii::TrilinosWrappers::SparseMatrix &C,
+    dealii::TrilinosWrappers::SparseMatrix const &B, Operator const &A)
+{
+  // C = A * B^T
+  // C_ij = A_ik * B^T_kj = A_ik * B_jk
+
+  auto tmp = A.build_range_vector();
+  std::vector<dealii::types::global_dof_index> i_indices;
+  tmp->locally_owned_elements().fill_index_vector(i_indices);
+  std::vector<dealii::types::global_dof_index> j_indices;
+  B.locally_owned_range_indices().fill_index_vector(j_indices);
+
+  int const global_n_rows = tmp->size();
+  int const global_n_columns = B.m(); //< number of rows in B
+  for (int j = 0; j < global_n_columns; ++j)
+  {
+    auto const src = extract_row(B, j);
+
+    std::remove_const<decltype(src)>::type dst(tmp->locally_owned_elements(),
+                                               tmp->get_mpi_communicator());
+    A.apply(src, dst);
+
+    // NOTE: getting an error that the index set is not compressed when calling
+    // IndexSet::index_within_set() directly on dst.locally_owned_elements() so
+    // ended up making a copy and calling IndexSet::compress() on it.  Not sure
+    // it is the best solution but this will do for now.
+    auto index_set = dst.locally_owned_elements();
+    index_set.compress();
+    for (int i = 0; i < global_n_rows; ++i)
+    {
+      auto const local_i = index_set.index_within_set(i);
+      if (local_i != dealii::numbers::invalid_dof_index)
+      {
+        auto const value = dst[i];
+        if (std::abs(value) > 1e-14) // is that an appropriate epsilon?
+        {
+          C.set(i, j, value);
+        }
+      }
+    }
+  }
+  C.compress(dealii::VectorOperation::insert);
+}
+
+void matrix_market_output_file(
+    const std::string &filename,
+    const dealii::TrilinosWrappers::SparseMatrix &matrix);
+
+void matrix_market_output_file(
+    const std::string &filename,
+    const dealii::TrilinosWrappers::MPI::Vector &vector);
+} // namespace mfmg
+
+#endif

--- a/source/common/utils.cc
+++ b/source/common/utils.cc
@@ -9,11 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                 *
  *************************************************************************/
 
-#include <mfmg/common/exceptions.hpp>
 #include <mfmg/common/utils.hpp>
-
-#include <EpetraExt_MultiVectorOut.h>
-#include <EpetraExt_RowMatrixOut.h>
 
 #include <Teuchos_XMLParameterListCoreHelpers.hpp>
 
@@ -21,29 +17,6 @@
 
 namespace mfmg
 {
-
-// TODO: write down 4 maps
-void matrix_market_output_file(
-    const std::string &filename,
-    const dealii::TrilinosWrappers::SparseMatrix &matrix)
-{
-  int rv = EpetraExt::RowMatrixToMatrixMarketFile(filename.c_str(),
-                                                  matrix.trilinos_matrix());
-  ASSERT(rv == 0, "EpetraExt::RowMatrixToMatrixMarketFile return value is " +
-                      std::to_string(rv));
-}
-
-// TODO: write the map
-void matrix_market_output_file(
-    const std::string &filename,
-    const dealii::TrilinosWrappers::MPI::Vector &vector)
-{
-  int rv = EpetraExt::MultiVectorToMatrixMarketFile(filename.c_str(),
-                                                    vector.trilinos_vector());
-  ASSERT(rv == 0, "EpetraExt::RowMatrixToMatrixMarketFile return value is " +
-                      std::to_string(rv));
-}
-
 static std::ostream &
 ptree2plist_internal(boost::property_tree::ptree const &node, std::ostream &os)
 {

--- a/source/dealii/CMakeLists.txt
+++ b/source/dealii/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(MFMG_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_matrix_free_hierarchy_helpers.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_matrix_free_smoother.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dealii_matrix_free_mesh_evaluator.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dealii_utils.cc
   )
 
 SET(MFMG_SOURCES ${MFMG_SOURCES} PARENT_SCOPE)

--- a/source/dealii/dealii_matrix_free_operator.cc
+++ b/source/dealii/dealii_matrix_free_operator.cc
@@ -14,107 +14,12 @@
 #include <mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp>
 #include <mfmg/dealii/dealii_matrix_free_operator.hpp>
 #include <mfmg/dealii/dealii_trilinos_matrix_operator.hpp>
+#include <mfmg/dealii/dealii_utils.hpp>
 
 #include <deal.II/lac/la_parallel_vector.h>
 
 namespace mfmg
 {
-namespace
-{
-dealii::LinearAlgebra::distributed::Vector<double>
-extract_row(dealii::TrilinosWrappers::SparseMatrix const &matrix,
-            dealii::types::global_dof_index global_j)
-{
-  int num_entries = 0;
-  double *values = nullptr;
-  int *local_indices = nullptr;
-  ASSERT(matrix.trilinos_matrix().IndicesAreLocal(), "Indices are not local");
-  auto const local_j =
-      matrix.locally_owned_range_indices().index_within_set(global_j);
-  if (local_j != dealii::numbers::invalid_dof_index)
-  {
-    auto const error_code = matrix.trilinos_matrix().ExtractMyRowView(
-        local_j, num_entries, values, local_indices);
-    ASSERT(error_code == 0,
-           "Non-zero error code (" + std::to_string(error_code) +
-               ") returned by Epetra_CrsMatrix::ExtractMyRowView()");
-  }
-
-  dealii::IndexSet ghost_indices(matrix.locally_owned_domain_indices().size());
-  for (int k = 0; k < num_entries; ++k)
-  {
-    ghost_indices.add_index(matrix.trilinos_matrix().GCID(local_indices[k]));
-  }
-  ghost_indices.compress();
-  dealii::LinearAlgebra::distributed::Vector<double> ghosted_vector(
-      matrix.locally_owned_domain_indices(), ghost_indices,
-      matrix.get_mpi_communicator());
-  ghosted_vector = 0.;
-  for (int k = 0; k < num_entries; ++k)
-  {
-    auto const global_index = matrix.trilinos_matrix().GCID(local_indices[k]);
-    ghosted_vector[global_index] = values[k];
-  }
-  ghosted_vector.compress(dealii::VectorOperation::add);
-
-  dealii::LinearAlgebra::distributed::Vector<double> vector(
-      matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator());
-  vector = ghosted_vector;
-  return vector;
-}
-
-// matrix_transpose_matrix_multiply(C, B, A) performs the matrix-matrix
-// multiplication with the transpose of B, i.e. C = A * B^T
-//
-// Note that it is different from deal.II's SparseMatrix::Tmmult(C, B) which
-// performs C = A^T * B
-template <typename Operator>
-void matrix_transpose_matrix_multiply(
-    dealii::TrilinosWrappers::SparseMatrix &C,
-    dealii::TrilinosWrappers::SparseMatrix const &B, Operator const &A)
-{
-  // C = A * B^T
-  // C_ij = A_ik * B^T_kj = A_ik * B_jk
-
-  auto tmp = A.build_range_vector();
-  std::vector<dealii::types::global_dof_index> i_indices;
-  tmp->locally_owned_elements().fill_index_vector(i_indices);
-  std::vector<dealii::types::global_dof_index> j_indices;
-  B.locally_owned_range_indices().fill_index_vector(j_indices);
-
-  int const global_n_rows = tmp->size();
-  int const global_n_columns = B.m(); //< number of rows in B
-  for (int j = 0; j < global_n_columns; ++j)
-  {
-    auto const src = extract_row(B, j);
-
-    std::remove_const<decltype(src)>::type dst(tmp->locally_owned_elements(),
-                                               tmp->get_mpi_communicator());
-    A.vmult(dst, src);
-
-    // NOTE: getting an error that the index set is not compressed when calling
-    // IndexSet::index_within_set() directly on dst.locally_owned_elements() so
-    // ended up making a copy and calling IndexSet::compress() on it.  Not sure
-    // it is the best solution but this will do for now.
-    auto index_set = dst.locally_owned_elements();
-    index_set.compress();
-    for (int i = 0; i < global_n_rows; ++i)
-    {
-      auto const local_i = index_set.index_within_set(i);
-      if (local_i != dealii::numbers::invalid_dof_index)
-      {
-        auto const value = dst[i];
-        if (std::abs(value) > 1e-14) // is that an appropriate epsilon?
-        {
-          C.set(i, j, value);
-        }
-      }
-    }
-  }
-  C.compress(dealii::VectorOperation::insert);
-}
-} // namespace
-
 template <typename VectorType>
 DealIIMatrixFreeOperator<VectorType>::DealIIMatrixFreeOperator(
     std::shared_ptr<MeshEvaluator> matrix_free_mesh_evaluator)

--- a/source/dealii/dealii_utils.cc
+++ b/source/dealii/dealii_utils.cc
@@ -1,0 +1,83 @@
+/*************************************************************************
+ * Copyright (c) 2017-2018 by the mfmg authors                           *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * This file is part of the mfmg libary. mfmg is distributed under a BSD *
+ * 3-clause license. For the licensing terms see the LICENSE file in the *
+ * top-level directory                                                   *
+ *                                                                       *
+ * SPDX-License-Identifier: BSD-3-Clause                                 *
+ *************************************************************************/
+
+#include <mfmg/common/exceptions.hpp>
+#include <mfmg/dealii/dealii_utils.hpp>
+
+#include <EpetraExt_MultiVectorOut.h>
+#include <EpetraExt_RowMatrixOut.h>
+
+namespace mfmg
+{
+dealii::LinearAlgebra::distributed::Vector<double>
+extract_row(dealii::TrilinosWrappers::SparseMatrix const &matrix,
+            dealii::types::global_dof_index global_j)
+{
+  int num_entries = 0;
+  double *values = nullptr;
+  int *local_indices = nullptr;
+  ASSERT(matrix.trilinos_matrix().IndicesAreLocal(), "Indices are not local");
+  auto const local_j =
+      matrix.locally_owned_range_indices().index_within_set(global_j);
+  if (local_j != dealii::numbers::invalid_dof_index)
+  {
+    auto const error_code = matrix.trilinos_matrix().ExtractMyRowView(
+        local_j, num_entries, values, local_indices);
+    ASSERT(error_code == 0,
+           "Non-zero error code (" + std::to_string(error_code) +
+               ") returned by Epetra_CrsMatrix::ExtractMyRowView()");
+  }
+
+  dealii::IndexSet ghost_indices(matrix.locally_owned_domain_indices().size());
+  for (int k = 0; k < num_entries; ++k)
+  {
+    ghost_indices.add_index(matrix.trilinos_matrix().GCID(local_indices[k]));
+  }
+  ghost_indices.compress();
+  dealii::LinearAlgebra::distributed::Vector<double> ghosted_vector(
+      matrix.locally_owned_domain_indices(), ghost_indices,
+      matrix.get_mpi_communicator());
+  ghosted_vector = 0.;
+  for (int k = 0; k < num_entries; ++k)
+  {
+    auto const global_index = matrix.trilinos_matrix().GCID(local_indices[k]);
+    ghosted_vector[global_index] = values[k];
+  }
+  ghosted_vector.compress(dealii::VectorOperation::add);
+
+  dealii::LinearAlgebra::distributed::Vector<double> vector(
+      matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator());
+  vector = ghosted_vector;
+  return vector;
+}
+
+// TODO: write down 4 maps
+void matrix_market_output_file(
+    const std::string &filename,
+    const dealii::TrilinosWrappers::SparseMatrix &matrix)
+{
+  int rv = EpetraExt::RowMatrixToMatrixMarketFile(filename.c_str(),
+                                                  matrix.trilinos_matrix());
+  ASSERT(rv == 0, "EpetraExt::RowMatrixToMatrixMarketFile return value is " +
+                      std::to_string(rv));
+}
+
+// TODO: write the map
+void matrix_market_output_file(
+    const std::string &filename,
+    const dealii::TrilinosWrappers::MPI::Vector &vector)
+{
+  int rv = EpetraExt::MultiVectorToMatrixMarketFile(filename.c_str(),
+                                                    vector.trilinos_vector());
+  ASSERT(rv == 0, "EpetraExt::RowMatrixToMatrixMarketFile return value is " +
+                      std::to_string(rv));
+}
+} // namespace mfmg


### PR DESCRIPTION
The biggest change is that I moved the function `matrix_transpose_matrix_multiply` and its dependency out of `dealii_matrix_free_operator.cc` because I need it for CUDA