### PR TITLE
Lanczos tests

### DIFF
--- a/include/mfmg/dealii/amge_host.templates.hpp
+++ b/include/mfmg/dealii/amge_host.templates.hpp
@@ -192,7 +192,13 @@ AMGe_host<dim, MeshEvaluator, VectorType>::compute_local_eigenvectors(
   {
     boost::property_tree::ptree lanczos_params;
     lanczos_params.put("num_eigenpairs", n_eigenvectors);
-    lanczos_params.put("tolerance", tolerance);
+    // We are having trouble with Lanczos when tolerance is too tight.
+    // Typically, it results in spurious eigenvalues (so far, only noticed 0).
+    // This seems to be the result of producing too many Lanczos vectors. For
+    // hierarchy_3d tests, any tolerance below 1e-5 (e.g., 1e-6) produces this
+    // problem. Thus, we try to work around it here. It is still unclear how
+    // robust this is.
+    lanczos_params.put("tolerance", std::max(tolerance, 1e-4));
     lanczos_params.put("max_iterations",
                        _eigensolver_params.get("max_iterations", 200));
     lanczos_params.put("percent_overshoot",

--- a/include/mfmg/dealii/lanczos.hpp
+++ b/include/mfmg/dealii/lanczos.hpp
@@ -47,8 +47,8 @@ private:
                         VectorType const &initial_guess);
 
   static std::tuple<std::vector<double>, std::vector<double>>
-  details_calc_tridiag_epairs(std::vector<double> const &t_maindiag,
-                              std::vector<double> const &t_offdiag,
+  details_calc_tridiag_epairs(std::vector<double> const &main_diagonal,
+                              std::vector<double> const &sub_diagonal,
                               const int num_requested);
 
   static bool details_check_convergence(double beta, const int num_evecs,

--- a/include/mfmg/dealii/lanczos.templates.hpp
+++ b/include/mfmg/dealii/lanczos.templates.hpp
@@ -268,7 +268,13 @@ Lanczos<OperatorType, VectorType>::details_calc_tridiag_epairs(
   std::vector<double> sub_diagonal_aux = sub_diagonal;
   std::vector<double> evecs_aux(n * n);
 
-  // Eigenvalues are returned in ascending order
+  // As the matrix is symmetric and tridiagonal, we use DSTEV LAPACK routine,
+  // which computes all eigenvalues and, optionally, eigenvectors of a real
+  // symmetric tridiagonal matrix A.
+  //   http://www.netlib.org/lapack/explore-html/d7/d48/dstev_8f.html
+  // It guarantees that the eigenvalues are returned in ascending order.
+  // NOTE: as some arguments are invalidated during the routine, we make a copy
+  // of the off-diagonal prior to the call.
   const lapack_int info =
       LAPACKE_dstev(LAPACK_COL_MAJOR, 'V', n, evals.data(),
                     sub_diagonal_aux.data(), evecs_aux.data(), n);

--- a/include/mfmg/dealii/lanczos.templates.hpp
+++ b/include/mfmg/dealii/lanczos.templates.hpp
@@ -161,8 +161,8 @@ Lanczos<OperatorType, VectorType>::details_solve_lanczos(
   if (lanc_vectors.size() < 1)
     lanc_vectors.push_back(initial_guess);
 
-  std::vector<double> t_maindiag;
-  std::vector<double> t_offdiag;
+  std::vector<double> main_diagonal;
+  std::vector<double> sub_diagonal;
 
   std::vector<double>
       evecs_tridiag; // eigenvectors of tridiagonal matrix, stored in flat array
@@ -189,12 +189,12 @@ Lanczos<OperatorType, VectorType>::details_solve_lanczos(
     if (it != 1)
     {
       lanc_vectors[it].add(-beta, lanc_vectors[it - 2]);
-      t_offdiag.push_back(beta);
+      sub_diagonal.push_back(beta);
     }
 
     alpha = lanc_vectors[it - 1] * lanc_vectors[it]; // = tridiag_{it,it}
 
-    t_maindiag.push_back(alpha);
+    main_diagonal.push_back(alpha);
 
     lanc_vectors[it].add(-alpha, lanc_vectors[it - 1]);
 
@@ -210,12 +210,12 @@ Lanczos<OperatorType, VectorType>::details_solve_lanczos(
     if (first_iteration || max_iterations_reached || percent_overshoot_exceeded)
     {
       const int dim_hessenberg = it;
-      ASSERT((size_t)dim_hessenberg == t_maindiag.size(), "Internal error");
+      ASSERT((size_t)dim_hessenberg == main_diagonal.size(), "Internal error");
 
       // Calculate eigenpairs of tridiagonal matrix for convergence test or at
       // last iteration
-      std::tie(evals, evecs_tridiag) =
-          details_calc_tridiag_epairs(t_maindiag, t_offdiag, num_requested);
+      std::tie(evals, evecs_tridiag) = details_calc_tridiag_epairs(
+          main_diagonal, sub_diagonal, num_requested);
 
       if (details_check_convergence(beta, dim_hessenberg, num_requested, tol,
                                     evecs_tridiag))
@@ -248,13 +248,13 @@ Lanczos<OperatorType, VectorType>::details_solve_lanczos(
 template <typename OperatorType, typename VectorType>
 std::tuple<std::vector<double>, std::vector<double>>
 Lanczos<OperatorType, VectorType>::details_calc_tridiag_epairs(
-    std::vector<double> const &t_maindiag, std::vector<double> const &t_offdiag,
-    const int num_requested)
+    std::vector<double> const &main_diagonal,
+    std::vector<double> const &sub_diagonal, const int num_requested)
 {
-  const int n = t_maindiag.size();
+  const int n = main_diagonal.size();
 
   ASSERT(n >= 1, "Internal error: tridigonal matrix size must be positive");
-  ASSERT(t_offdiag.size() == (size_t)(n - 1),
+  ASSERT(sub_diagonal.size() == (size_t)(n - 1),
          "Internal error: mismatch in main and off-diagonal sizes");
 
   std::vector<double> evals;
@@ -263,22 +263,16 @@ Lanczos<OperatorType, VectorType>::details_calc_tridiag_epairs(
   if (n < num_requested)
     return std::make_tuple(evals, evecs);
 
-  // Allocate storage
-  std::vector<double> matrix(n * n, 0.);
-
-  // Copy diagonals of the tridiagonal matrix into the full matrix
-  matrix[0] = t_maindiag[0];
-  for (int i = 1; i < n; ++i)
-  {
-    matrix[i + n * i] = t_maindiag[i];
-    matrix[i - 1 + n * i] = t_offdiag[i - 1];
-  }
+  // dstyev destroys storage
+  evals = main_diagonal;
+  std::vector<double> sub_diagonal_aux = sub_diagonal;
+  std::vector<double> evecs_aux(n * n);
 
   // Eigenvalues are returned in ascending order
-  evals.resize(n);
-  const lapack_int info = LAPACKE_dsyev(LAPACK_COL_MAJOR, 'V', 'U', n,
-                                        matrix.data(), n, evals.data());
-  ASSERT(!info, "Call to LAPACKE_dsyev failed.");
+  const lapack_int info =
+      LAPACKE_dstev(LAPACK_COL_MAJOR, 'V', n, evals.data(),
+                    sub_diagonal_aux.data(), evecs_aux.data(), n);
+  ASSERT(!info, "Call to LAPACKE_dstev failed.");
 
   // Save results.
   evals.resize(num_requested);
@@ -286,11 +280,11 @@ Lanczos<OperatorType, VectorType>::details_calc_tridiag_epairs(
   for (int i = 0; i < num_requested; ++i)
   {
     auto first = evecs.begin() + n * i;
-    auto t_first = matrix.begin() + n * i;
-    auto t_last = t_first + n;
+    auto aux_first = evecs_aux.begin() + n * i;
+    auto aux_last = aux_first + n;
     double const norm =
-        std::sqrt(std::inner_product(t_first, t_last, t_first, 0.));
-    std::transform(t_first, t_last, first,
+        std::sqrt(std::inner_product(aux_first, aux_last, aux_first, 0.));
+    std::transform(aux_first, aux_last, first,
                    [norm](auto &v) { return v / norm; });
   }
 

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -73,10 +73,6 @@ double test(std::shared_ptr<boost::property_tree::ptree> params)
       laplace._dof_handler, laplace._constraints, a, material_property);
   mfmg::Hierarchy<DVector> hierarchy(comm, evaluator, params);
 
-  pcout << "Grid complexity    : " << hierarchy.grid_complexity() << std::endl;
-  pcout << "Operator complexity: " << hierarchy.operator_complexity()
-        << std::endl;
-
   // We want to do 20 V-cycle iterations. The rhs of is zero.
   // Use D(istributed)Vector because deal has its own Vector class
   DVector residual(rhs);

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -158,7 +158,7 @@ BOOST_DATA_TEST_CASE(
         bdata::make({"None", "Reverse Cuthill_McKee"}) *
         bdata::make<std::string>({"DealIIMeshEvaluator",
                                   "DealIIMatrixFreeMeshEvaluator"}) *
-        bdata::make<std::string>({"lapack"}),
+        bdata::make<std::string>({"lapack", "lanczos"}),
     mesh, distort_random, reordering, mesh_evaluator_type, eigensolver)
 {
   // TODO investigate why there is large difference in convergence rate when
@@ -201,22 +201,38 @@ BOOST_DATA_TEST_CASE(
              double>
         ref_solution;
     // clang-format off
-    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lapack" , "matrix-full")] = 0.0491724046;
-    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lapack" , "matrix-free")] = 0.1482630509;
-    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lapack" , "matrix-full")] = 0.0491724046;
-    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lapack" , "matrix-free")] = 0.1482630509;
-    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lapack" , "matrix-full")] = 0.0488984875;
-    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lapack" , "matrix-free")] = 0.1575262224;
-    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lapack" , "matrix-full")] = 0.0488984875;
-    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lapack" , "matrix-free")] = 0.1575262224;
-    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lapack" , "matrix-full")] = 0.1146629782;
-    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lapack" , "matrix-free")] = 0.3022004744;
-    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lapack" , "matrix-full")] = 0.1146629782;
-    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lapack" , "matrix-free")] = 0.3022004744;
-    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lapack" , "matrix-full")] = 0.1024334788;
-    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lapack" , "matrix-free")] = 0.2977841482;
-    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lapack" , "matrix-full")] = 0.1024334788;
-    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lapack" , "matrix-free")] = 0.2977841482;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lapack"  , "matrix-full")] = 0.0491724046;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lapack"  , "matrix-free")] = 0.1482630509;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lapack"  , "matrix-full")] = 0.0491724046;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lapack"  , "matrix-free")] = 0.1482630509;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lapack"  , "matrix-full")] = 0.0488984875;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lapack"  , "matrix-free")] = 0.1575262224;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lapack"  , "matrix-full")] = 0.0488984875;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lapack"  , "matrix-free")] = 0.1575262224;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lapack"  , "matrix-full")] = 0.1146629782;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lapack"  , "matrix-free")] = 0.3022004744;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lapack"  , "matrix-full")] = 0.1146629782;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lapack"  , "matrix-free")] = 0.3022004744;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lapack"  , "matrix-full")] = 0.1024334788;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lapack"  , "matrix-free")] = 0.2977841482;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lapack"  , "matrix-full")] = 0.1024334788;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lapack"  , "matrix-free")] = 0.2977841482;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lanczos" , "matrix-full")] = 0.0491724046;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "lanczos" , "matrix-free")] = 0.1482630509;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lanczos" , "matrix-full")] = 0.0491724046;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "lanczos" , "matrix-free")] = 0.1482630509;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lanczos" , "matrix-full")] = 0.0488984984;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "lanczos" , "matrix-free")] = 0.1575261909;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lanczos" , "matrix-full")] = 0.0488984984;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "lanczos" , "matrix-free")] = 0.1575261909;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lanczos" , "matrix-full")] = 0.1144340191;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "lanczos" , "matrix-free")] = 0.3018610435;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lanczos" , "matrix-full")] = 0.1144340191;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "lanczos" , "matrix-free")] = 0.3018610435;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lanczos" , "matrix-full")] = 0.1023442076;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "lanczos" , "matrix-free")] = 0.2977392400;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lanczos" , "matrix-full")] = 0.1023442076;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "lanczos" , "matrix-free")] = 0.2977392400;
     // clang-format on
 
     BOOST_TEST(

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -340,6 +340,6 @@ BOOST_DATA_TEST_CASE(weight_sum, bdata::make({"lapack", "lanczos"}),
       e[i] = 1.;
     e.compress(::dealii::VectorOperation::insert);
     restrictor_matrix.vmult(ee, e);
-    BOOST_TEST(ee.l1_norm() == 1., tt::tolerance(1e-4));
+    BOOST_TEST(ee.l1_norm() == 1., tt::tolerance(2e-4));
   }
 }

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -21,6 +21,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include <boost/property_tree/info_parser.hpp>
+#include <boost/test/data/test_case.hpp>
 
 #include <random>
 
@@ -28,6 +29,8 @@
 #include "main.cc"
 
 namespace utf = boost::unit_test;
+namespace bdata = boost::unit_test::data;
+namespace tt = boost::test_tools;
 
 template <int dim>
 class DummyMeshEvaluator : public mfmg::DealIIMeshEvaluator<dim>
@@ -279,7 +282,8 @@ private:
 
 // FIXME relaxed tolerance from 1e-14 to 1e-4 for this test to pass while using
 // ARPACK's regular mode instead of shift-and-invert
-BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-4))
+BOOST_DATA_TEST_CASE(weight_sum, bdata::make({"lapack", "lanczos"}),
+                     eigensolver)
 {
   // Check that the weight sum is equal to one
   unsigned int constexpr dim = 2;
@@ -295,6 +299,7 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-4))
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
+  params->put("eigensolver.type", eigensolver);
   params->put("eigensolver.number of eigenvectors", 1);
   auto agglomerate_ptree = params->get_child("agglomeration");
   int n_eigenvectors =
@@ -311,7 +316,8 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-4))
 
   TestMeshEvaluator<dim> evaluator(laplace._dof_handler, laplace._constraints,
                                    laplace._system_matrix);
-  mfmg::AMGe_host<dim, MeshEvaluator, DVector> amge(comm, laplace._dof_handler);
+  mfmg::AMGe_host<dim, MeshEvaluator, DVector> amge(
+      comm, laplace._dof_handler, params->get_child("eigensolver"));
 
   auto locally_relevant_global_diag = evaluator.get_diagonal();
 
@@ -334,6 +340,6 @@ BOOST_AUTO_TEST_CASE(weight_sum, *utf::tolerance(1e-4))
       e[i] = 1.;
     e.compress(::dealii::VectorOperation::insert);
     restrictor_matrix.vmult(ee, e);
-    BOOST_TEST(ee.l1_norm() == 1.);
+    BOOST_TEST(ee.l1_norm() == 1., tt::tolerance(1e-4));
   }
 }


### PR DESCRIPTION
An alternative version of #132. We don't introduce a new stopping criteria, and instead just loosen tolerance for the hierarchy tests.

Fix #115.