### PR TITLE
Reenable matrix-free hierarchy tests and fix associated bugs

### DIFF
--- a/include/mfmg/dealii/amge_host.templates.hpp
+++ b/include/mfmg/dealii/amge_host.templates.hpp
@@ -157,7 +157,7 @@ AMGe_host<dim, MeshEvaluator, VectorType>::compute_local_eigenvectors(
       n_eigenvectors, dealii::Vector<double>(n_dofs_agglomerate));
 
   auto const eigensolver_type =
-      _eigensolver_params.get<std::string>("type", "lancsoz");
+      _eigensolver_params.get<std::string>("type", "lanczos");
   if (eigensolver_type == "lanczos")
   {
     lanczos_compute_eigenvalues_and_eigenvectors(
@@ -176,7 +176,7 @@ AMGe_host<dim, MeshEvaluator, VectorType>::compute_local_eigenvectors(
   }
   else
   {
-    ASSERT(true, "Unknown eigensolver type '" + eigensolver_type + "'");
+    ASSERT(false, "Unknown eigensolver type '" + eigensolver_type + "'");
   }
 
   // Compute the map between the local and the global dof indices.
@@ -288,7 +288,7 @@ AMGe_host<dim, MeshEvaluator, VectorType>::compute_local_eigenvectors(
   }
   else
   {
-    ASSERT(true, "Unknown eigensolver type '" + eigensolver_type + "'");
+    ASSERT(false, "Unknown eigensolver type '" + eigensolver_type + "'");
   }
 
   // Compute the map between the local and the global dof indices.

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -113,7 +113,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(benchmark, MeshEvaluator, mesh_evaluator_types)
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
   if (mfmg::is_matrix_free<MeshEvaluator>::value)
   {
-    return; // FIXME temporarily disabling in matrix-free mode
     params->put("smoother.type", "Chebyshev");
   }
 
@@ -126,7 +125,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ml, MeshEvaluator, mesh_evaluator_types)
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
   if (mfmg::is_matrix_free<MeshEvaluator>::value)
   {
-    return; // FIXME temporarily disabling in matrix-free mode
     params->put("smoother.type", "Chebyshev");
   }
 
@@ -249,7 +247,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(zoltan, MeshEvaluator, mesh_evaluator_types)
     bool constexpr is_matrix_free = mfmg::is_matrix_free<MeshEvaluator>::value;
     if (is_matrix_free)
     {
-      return; // FIXME temporarily disabling in matrix-free mode
       params->put("smoother.type", "Chebyshev");
     }
 


### PR DESCRIPTION
Two bugs (misspelled default and `ASSERT(true)` instead of `ASSERT(false)`)
were canceling each other, and we never noticed.

Co-authored-by: Damien L-G <dalg24@gmail.com>