### PR TITLE
Fix compiling with CUDA_MPI=ON

### DIFF
--- a/source/cuda/utils.cu
+++ b/source/cuda/utils.cu
@@ -367,7 +367,7 @@ void all_gather_dev(MPI_Comm communicator, unsigned int send_count,
 {
   // First gather the number of elements each proc will send
   int comm_size;
-  MPI_Comm_size(&communicator, &comm_size);
+  MPI_Comm_size(communicator, &comm_size);
   if (comm_size > 1)
   {
     all_gather(communicator, send_count, send_buffer, recv_count, recv_buffer);


### PR DESCRIPTION
The signature for `MPI_Comm_size` is
```
int MPI_Comm_size(MPI_Comm comm, int *size)
```