### PR TITLE
Fix CI

### DIFF
--- a/ci/compile_and_run.sh
+++ b/ci/compile_and_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-cd $1
+cd $1 || exit 1
 rm -rf build
-mkdir build && cd build
+mkdir build && cd build || exit 1
 ARGS=(
   -D CMAKE_BUILD_TYPE=Debug
   -D MFMG_ENABLE_TESTS=ON
@@ -15,7 +15,7 @@ ARGS=(
   -D AMGX_DIR=${AMGX_DIR}
   -D CMAKE_CXX_FLAGS="-Wall -Wpedantic -Wextra -Wshadow"
   )
-cmake "${ARGS[@]}" ../
+cmake "${ARGS[@]}" ../ || exit 1
 make -j12
 # Because Arpack is not thread-safe we cannot use multithreading
 export DEAL_II_NUM_THREADS=1

--- a/ci/compile_and_run.sh
+++ b/ci/compile_and_run.sh
@@ -14,6 +14,7 @@ ARGS=(
   -D MFMG_ENABLE_AMGX=ON
   -D AMGX_DIR=${AMGX_DIR}
   -D CMAKE_CXX_FLAGS="-Wall -Wpedantic -Wextra -Wshadow"
+  -D LAPACK_DIR=${OPENBLAS_DIR}
   )
 cmake "${ARGS[@]}" ../ || exit 1
 make -j12

--- a/cmake/SetupTPLs.cmake
+++ b/cmake/SetupTPLs.cmake
@@ -39,16 +39,33 @@ ELSE()
 ENDIF()
 
 #### LAPACKE #################################################################
-FIND_LIBRARY(LAPACKE_LIBRARY NAMES lapacke
-             HINTS ${LAPACK_DIR} $ENV{LAPACK_DIR}
-             PATH_SUFFIXES lib)
 FIND_PATH(LAPACKE_INCLUDE_DIR lapacke.h
           HINTS ${LAPACK_DIR} $ENV{LAPACK_DIR}
           PATH_SUFFIXES include)
 
-IF(NOT LAPACKE_INCLUDE_DIR OR NOT LAPACKE_LIBRARY)
+IF(NOT LAPACKE_INCLUDE_DIR)
+  MESSAGE(STATUS "${LAPACKE_INCLUDE_DIR}")
   MESSAGE(FATAL_ERROR
           "Error! Could not locate LAPACKE.")
+ENDIF()
+
+# First test if the libraries deal.II links to already include LAPACKE
+INCLUDE(CheckFunctionExists)
+SET(CMAKE_REQUIRED_LIBRARIES "${DEAL_II_LIBRARIES}")
+CHECK_FUNCTION_EXISTS(LAPACKE_dgeqrf LAPACKE_WORKS)
+
+# If not try to find a separate library
+IF (LAPACKE_WORKS)
+  SET(LAPACKE_LIBRARY "")
+ELSE()
+  FIND_LIBRARY(LAPACKE_LIBRARY NAMES lapacke
+               HINTS ${LAPACK_DIR} $ENV{LAPACK_DIR}
+               PATH_SUFFIXES lib)
+
+  IF(NOT LAPACKE_LIBRARY)
+    MESSAGE(FATAL_ERROR
+            "Error! Could not locate LAPACKE.")
+  ENDIF()
 ENDIF()
 
 #### AMGX ####################################################################


### PR DESCRIPTION
This PR makes sure that we fail if the `cmake` call isn't successfull. Furthermore, we first try if the `LAPACK` interface provided by `deal.II` is sufficient for `LAPACKE` and only search for an additional library if that fails.

Alternative to #158.