### PR TITLE
Factor eigenvalues out of eigenvector_matrix

### DIFF
--- a/include/mfmg/common/amge.templates.hpp
+++ b/include/mfmg/common/amge.templates.hpp
@@ -441,7 +441,7 @@ void AMGe<dim, VectorType>::compute_restriction_sparse_matrix(
                 eigenvectors[pos][j]);
         // Fill eigenvector sparse matrix
         eigenvector_sparse_matrix->add(local_range.first + pos, global_pos,
-                                       eigenvalues[pos] * eigenvectors[pos][j]);
+                                       eigenvectors[pos][j]);
         // Fill delta eigenvector sparse matrix
         delta_eigenvector_matrix->set(
             local_range.first + pos, global_pos,

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -170,8 +170,7 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
                 {
                   delta_eig[k] =
                       delta_eigenvector_matrix->el(row, dof_indices_map[k]) +
-                      eigenvector_matrix->el(row, dof_indices_map[k]) /
-                          eigenvalues[row];
+                      eigenvector_matrix->el(row, dof_indices_map[k]);
                 }
               }
               else
@@ -231,6 +230,12 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
     Epetra_Map range_map = eigenvector_matrix->domain_partitioner();
     Epetra_Map domain_map = eigenvector_matrix->range_partitioner();
 #pragma GCC diagnostic pop
+
+    for (unsigned int row = 0; row < eigenvector_matrix->m(); ++row)
+      for (auto column_iterator = eigenvector_matrix->begin(row);
+           column_iterator != eigenvector_matrix->end(row); ++column_iterator)
+        column_iterator->value() *= eigenvalues[row];
+    eigenvector_matrix->compress(dealii::VectorOperation::insert);
 
     bool const transpose = true;
     int error_code = EpetraExt::MatrixMatrix::Add(

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -162,8 +162,7 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
                 {
                   delta_eig[k] =
                       delta_eigenvector_matrix->el(row, dof_indices_map[k]) +
-                      eigenvector_matrix->el(row, dof_indices_map[k]) /
-                          eigenvalues[row];
+                      eigenvector_matrix->el(row, dof_indices_map[k]);
                 }
               }
               else
@@ -224,6 +223,12 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     Epetra_Map range_map = eigenvector_matrix->domain_partitioner();
     Epetra_Map domain_map = eigenvector_matrix->range_partitioner();
 #pragma GCC diagnostic pop
+
+    for (unsigned int row = 0; row < eigenvector_matrix->m(); ++row)
+      for (auto column_iterator = eigenvector_matrix->begin(row);
+           column_iterator != eigenvector_matrix->end(row); ++column_iterator)
+        column_iterator->value() *= eigenvalues[row];
+    eigenvector_matrix->compress(dealii::VectorOperation::insert);
 
     bool const transpose = true;
     int error_code = EpetraExt::MatrixMatrix::Add(


### PR DESCRIPTION
Previously we were multiplying the eigenvector by the eigenvalue. In case of zero eigenvalues, this means that we are loosing information about the eigenvector.

Related to MPI for Fast AP.