### PR TITLE
Rework hierarchy_driver and add timer

### DIFF
--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -4,8 +4,78 @@
 
 #include "test_hierarchy_helpers.hpp"
 
+template <int dim, int fe_degree>
+void matrix_free_two_grids(std::shared_ptr<boost::property_tree::ptree> params)
+{
+
+  using DVector = dealii::LinearAlgebra::distributed::Vector<double>;
+
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  dealii::ConditionalOStream pcout(
+      std::cout, dealii::Utilities::MPI::this_mpi_process(comm) == 0);
+
+  auto material_property =
+      MaterialPropertyFactory<dim>::create_material_property(
+          params->get<std::string>("material_property.type"));
+  Source<dim> source;
+
+  auto laplace_ptree = params->get_child("laplace");
+  LaplaceMatrixFree<dim, fe_degree, double> mf_laplace(comm);
+  mf_laplace.setup_system(laplace_ptree, *material_property);
+
+  auto const locally_owned_dofs = mf_laplace._locally_owned_dofs;
+  DVector solution(locally_owned_dofs, comm);
+  DVector rhs(mf_laplace._system_rhs);
+
+  std::default_random_engine generator;
+  std::uniform_real_distribution<typename DVector::value_type> distribution(0.,
+                                                                            1.);
+  for (auto const index : locally_owned_dofs)
+  {
+    // Make the solution satisfy the Dirichlet conditions because these should
+    // be treated outside the preconditioner
+    if (mf_laplace._constraints.is_constrained(index))
+      solution[index] = 0.;
+    else
+      solution[index] = distribution(generator);
+  }
+
+  auto evaluator =
+      std::make_shared<TestMFMeshEvaluator<dim, fe_degree, double>>(
+          mf_laplace._dof_handler, mf_laplace._constraints,
+          mf_laplace._laplace_operator, material_property);
+  mfmg::Hierarchy<DVector> hierarchy(comm, evaluator, params);
+
+  // We want to do 20 V-cycle iterations. The rhs of is zero.
+  // Use D(istributed)Vector because deal has its own Vector class
+  DVector residual(rhs);
+  unsigned int const n_cycles = 20;
+  std::vector<double> res(n_cycles + 1);
+
+  mf_laplace._laplace_operator.vmult(residual, solution);
+  residual.sadd(-1., 1., rhs);
+  auto const residual0_norm = residual.l2_norm();
+
+  std::cout << std::scientific;
+  res[0] = 1.0;
+  for (unsigned int i = 0; i < n_cycles; ++i)
+  {
+    hierarchy.apply(rhs, solution);
+
+    mf_laplace._laplace_operator.vmult(residual, solution);
+    residual.sadd(-1., 1., rhs);
+    double rel_residual = residual.l2_norm() / residual0_norm;
+    res[i + 1] = rel_residual;
+  }
+
+  double const conv_rate = res[n_cycles] / res[n_cycles - 1];
+  pcout << "Convergence rate: " << std::fixed << std::setprecision(2)
+        << conv_rate << std::endl;
+}
+
 template <int dim>
-void main_(std::shared_ptr<boost::property_tree::ptree> params)
+void matrix_based_two_grids(std::shared_ptr<boost::property_tree::ptree> params)
 {
   using DVector = dealii::LinearAlgebra::distributed::Vector<double>;
   using MeshEvaluator = mfmg::DealIIMeshEvaluator<dim>;
@@ -35,17 +105,20 @@ void main_(std::shared_ptr<boost::property_tree::ptree> params)
   std::uniform_real_distribution<typename DVector::value_type> distribution(0.,
                                                                             1.);
   for (auto const index : locally_owned_dofs)
-    solution[index] = distribution(generator);
+  {
+    // Make the solution satisfy the Dirichlet conditions because these should
+    // be treated outside the preconditioner
+    if (laplace._constraints.is_constrained(index))
+      solution[index] = 0.;
+    else
+      solution[index] = distribution(generator);
+  }
 
   std::shared_ptr<MeshEvaluator> evaluator(
       new TestMeshEvaluator<mfmg::DealIIMeshEvaluator<dim>>(
           laplace._dof_handler, laplace._constraints, fe_degree, a,
           material_property));
   mfmg::Hierarchy<DVector> hierarchy(comm, evaluator, params);
-
-  pcout << "Grid complexity    : " << hierarchy.grid_complexity() << std::endl;
-  pcout << "Operator complexity: " << hierarchy.operator_complexity()
-        << std::endl;
 
   // We want to do 20 V-cycle iterations. The rhs of is zero.
   // Use D(istributed)Vector because deal has its own Vector class
@@ -58,7 +131,6 @@ void main_(std::shared_ptr<boost::property_tree::ptree> params)
   auto const residual0_norm = residual.l2_norm();
 
   std::cout << std::scientific;
-  // pcout << "#0: " << 1.0 << std::endl;
   res[0] = 1.0;
   for (unsigned int i = 0; i < n_cycles; ++i)
   {
@@ -67,7 +139,6 @@ void main_(std::shared_ptr<boost::property_tree::ptree> params)
     a.vmult(residual, solution);
     residual.sadd(-1., 1., rhs);
     double rel_residual = residual.l2_norm() / residual0_norm;
-    // pcout << "#" << i + 1 << ": " << rel_residual << std::endl;
     res[i + 1] = rel_residual;
   }
 
@@ -80,38 +151,198 @@ int main(int argc, char *argv[])
 {
   namespace boost_po = boost::program_options;
 
-  using f_type = std::vector<std::string>;
-
   MPI_Init(&argc, &argv);
 
   boost_po::options_description cmd("Available options");
-  cmd.add_options()("filename,f", boost_po::value<f_type>()->multitoken(),
-                    "file(s) containing input parameters");
+  cmd.add_options()("help,h", "produce help message");
+  cmd.add_options()("filename,f", boost_po::value<std::string>()->multitoken(),
+                    "file containing input parameters");
   cmd.add_options()("dim,d", boost_po::value<int>(), "dimension");
+  cmd.add_options()("matrix_free,m", boost_po::value<bool>(),
+                    "use matrix-free algorithm");
 
   boost_po::variables_map vm;
   boost_po::store(boost_po::parse_command_line(argc, argv, cmd), vm);
   boost_po::notify(vm);
 
-  f_type filenames = {"hierarchy_input.info"};
+  if (vm.count("help"))
+  {
+    std::cout << cmd << std::endl;
+
+    return 0;
+  }
+
+  std::string filename = {"hierarchy_input.info"};
   if (vm.count("filename"))
-    filenames = vm["filename"].as<f_type>();
+    filename = vm["filename"].as<std::string>();
 
   int dim = 2;
   if (vm.count("dim"))
     dim = vm["dim"].as<int>();
-
   mfmg::ASSERT(dim == 2 || dim == 3, "Dimension must be 2 or 3");
 
-  for (auto &filename : filenames)
-  {
-    auto params = std::make_shared<boost::property_tree::ptree>();
-    boost::property_tree::info_parser::read_info(filename, *params);
+  bool matrix_free = true;
+  if (vm.count("matrix_free"))
+    matrix_free = vm["matrix_free"].as<bool>();
 
+  auto params = std::make_shared<boost::property_tree::ptree>();
+  boost::property_tree::info_parser::read_info(filename, *params);
+
+  int fe_degree = params->get<unsigned int>("laplace.fe_degree", 1);
+
+  std::cout << "input file: " << filename << ", dimension: " << dim
+            << ", matrix-free: " << matrix_free << ", fe_degree: " << fe_degree
+            << std::endl;
+
+  if (matrix_free)
+  {
     if (dim == 2)
-      main_<2>(params);
+    {
+      switch (fe_degree)
+      {
+      case 1:
+      {
+        matrix_free_two_grids<2, 1>(params);
+
+        break;
+      }
+      case 2:
+      {
+        matrix_free_two_grids<2, 2>(params);
+
+        break;
+      }
+      case 3:
+      {
+        matrix_free_two_grids<2, 3>(params);
+
+        break;
+      }
+      case 4:
+      {
+        matrix_free_two_grids<2, 4>(params);
+
+        break;
+      }
+      case 5:
+      {
+        matrix_free_two_grids<2, 5>(params);
+
+        break;
+      }
+      case 6:
+      {
+        matrix_free_two_grids<2, 6>(params);
+
+        break;
+      }
+      case 7:
+      {
+        matrix_free_two_grids<2, 7>(params);
+
+        break;
+      }
+      case 8:
+      {
+        matrix_free_two_grids<2, 8>(params);
+
+        break;
+      }
+      case 9:
+      {
+        matrix_free_two_grids<2, 9>(params);
+
+        break;
+      }
+      case 10:
+      {
+        matrix_free_two_grids<2, 10>(params);
+
+        break;
+      }
+      default:
+      {
+        mfmg::ASSERT(false, "The fe_degree should be between 1 and 10");
+      }
+      }
+    }
     else
-      main_<3>(params);
+    {
+      switch (fe_degree)
+      {
+      case 1:
+      {
+        matrix_free_two_grids<3, 1>(params);
+
+        break;
+      }
+      case 2:
+      {
+        matrix_free_two_grids<3, 2>(params);
+
+        break;
+      }
+      case 3:
+      {
+        matrix_free_two_grids<3, 3>(params);
+
+        break;
+      }
+      case 4:
+      {
+        matrix_free_two_grids<3, 4>(params);
+
+        break;
+      }
+      case 5:
+      {
+        matrix_free_two_grids<3, 5>(params);
+
+        break;
+      }
+      case 6:
+      {
+        matrix_free_two_grids<3, 6>(params);
+
+        break;
+      }
+      case 7:
+      {
+        matrix_free_two_grids<3, 7>(params);
+
+        break;
+      }
+      case 8:
+      {
+        matrix_free_two_grids<3, 8>(params);
+
+        break;
+      }
+      case 9:
+      {
+        matrix_free_two_grids<3, 9>(params);
+
+        break;
+      }
+      case 10:
+      {
+        matrix_free_two_grids<3, 10>(params);
+
+        break;
+      }
+      default:
+      {
+        mfmg::ASSERT(false, "The fe_degree should be between 1 and 10");
+      }
+      }
+    }
+  }
+  else
+  {
+    if (dim == 2)
+      matrix_based_two_grids<2>(params);
+    else
+      matrix_based_two_grids<3>(params);
   }
 
   MPI_Finalize();

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -27,11 +27,11 @@ void matrix_free_two_grids(std::shared_ptr<boost::property_tree::ptree> params)
           params->get<std::string>("material_property.type"));
   Source<dim> source;
 
-  auto laplace_ptree = params->get_child("laplace");
+  auto const &laplace_ptree = params->get_child("laplace");
   LaplaceMatrixFree<dim, fe_degree, double> mf_laplace(comm);
   mf_laplace.setup_system(laplace_ptree, *material_property);
 
-  auto const locally_owned_dofs = mf_laplace._locally_owned_dofs;
+  auto const &locally_owned_dofs = mf_laplace._locally_owned_dofs;
   DVector solution(locally_owned_dofs, comm);
   DVector rhs(mf_laplace._system_rhs);
 
@@ -197,10 +197,10 @@ int main(int argc, char *argv[])
   if (vm.count("matrix_free"))
     matrix_free = vm["matrix_free"].as<bool>();
 
-  auto params = std::make_shared<boost::property_tree::ptree>();
+  auto const params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info(filename, *params);
 
-  int fe_degree = params->get<unsigned int>("laplace.fe_degree", 1);
+  int const fe_degree = params->get<unsigned int>("laplace.fe_degree", 1);
 
   std::cout << "input file: " << filename << ", dimension: " << dim
             << ", matrix-free: " << matrix_free << ", fe_degree: " << fe_degree

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
     dim = vm["dim"].as<int>();
   mfmg::ASSERT(dim == 2 || dim == 3, "Dimension must be 2 or 3");
 
-  bool matrix_free = true;
+  bool matrix_free = false;
   if (vm.count("matrix_free"))
     matrix_free = vm["matrix_free"].as<bool>();
 


### PR DESCRIPTION
This PR reworks hierarchy_driver so that it can be used for profiling. Also add a few timers for some crude profiling.