### PR TITLE
Avoid initializing MFOperator on each vmult call

### DIFF
--- a/include/mfmg/dealii/amge_host.hpp
+++ b/include/mfmg/dealii/amge_host.hpp
@@ -131,7 +131,7 @@ private:
    * independent set of data.
    */
   void local_worker(unsigned int const n_eigenvectors, double const tolerance,
-                    MeshEvaluator const &evalute,
+                    MeshEvaluator const &evaluate,
                     std::vector<unsigned int>::iterator const &agg_id,
                     ScratchData &scratch_data, CopyData &copy_data);
 

--- a/include/mfmg/dealii/amge_host.templates.hpp
+++ b/include/mfmg/dealii/amge_host.templates.hpp
@@ -52,7 +52,7 @@ struct MatrixFreeAgglomerateOperator
       : _mesh_evaluator(mesh_evaluator), _dof_handler(dof_handler),
         _constraints(constraints)
   {
-    _mesh_evaluator.initialize_agglomerate(dof_handler);
+    _mesh_evaluator.matrix_free_initialize_agglomerate(dof_handler);
   }
 
   void vmult(dealii::Vector<double> &dst,

--- a/include/mfmg/dealii/amge_host.templates.hpp
+++ b/include/mfmg/dealii/amge_host.templates.hpp
@@ -52,18 +52,18 @@ struct MatrixFreeAgglomerateOperator
       : _mesh_evaluator(mesh_evaluator), _dof_handler(dof_handler),
         _constraints(constraints)
   {
+    _mesh_evaluator.initialize_agglomerate(dof_handler);
   }
 
   void vmult(dealii::Vector<double> &dst,
              const dealii::Vector<double> &src) const
   {
-    _mesh_evaluator.matrix_free_evaluate_agglomerate(_dof_handler, src, dst);
+    _mesh_evaluator.matrix_free_evaluate_agglomerate(src, dst);
   }
 
   std::vector<double> get_diag_elements() const
   {
-    return _mesh_evaluator.matrix_free_get_agglomerate_diagonal(_dof_handler,
-                                                                _constraints);
+    return _mesh_evaluator.matrix_free_get_agglomerate_diagonal(_constraints);
   }
 
   size_type m() const { return _dof_handler.n_dofs(); }
@@ -73,7 +73,7 @@ struct MatrixFreeAgglomerateOperator
 private:
   MeshEvaluator const &_mesh_evaluator;
   static int constexpr dim = MeshEvaluator::_dim;
-  dealii::DoFHandler<dim> &_dof_handler;
+  dealii::DoFHandler<dim> const &_dof_handler;
   dealii::AffineConstraints<double> &_constraints;
 };
 

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -27,29 +27,59 @@
 
 namespace mfmg
 {
+
+/**
+ * An interface class the user should derive from when defining an operator to
+ * be used in a matrix-free context.
+ */
 template <int dim>
 class DealIIMatrixFreeMeshEvaluator : public DealIIMeshEvaluator<dim>
 {
 public:
   using size_type = dealii::types::global_dof_index;
+
+  /**
+   * The dimension of the underlying mesh.
+   */
   static int constexpr _dim = dim;
 
+  /**
+   * The constructor is supposed to initialize the data required for performing
+   * operator evaluations on the global finite element space given by @p
+   * dof_handler and @p constraints.
+   */
   DealIIMatrixFreeMeshEvaluator(dealii::DoFHandler<dim> &dof_handler,
                                 dealii::AffineConstraints<double> &constraints);
 
+  /**
+   * Return the class name as std::string.
+   */
   std::string get_mesh_evaluator_type() const override final;
 
   std::shared_ptr<dealii::LinearAlgebra::distributed::Vector<double>>
   build_range_vector() const;
 
+  /**
+   * Return the dimension of the finite element space.
+   */
   dealii::types::global_dof_index m() const;
 
+  /**
+   * Initialize the operator for a given agglomerate described by @p
+   * dof_handler.
+   * @p dof_handler is expected to be initialized with a dealii::FiniteElement
+   * object in this call.
+   */
   virtual void matrix_free_initialize_agglomerate(
       dealii::DoFHandler<dim> & /*dof_handler*/) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
   }
 
+  /**
+   * Evaluate the operator on the agglomerate this object was initialized on in
+   * matrix_free_initialize_agglomerate().
+   */
   virtual void
   matrix_free_evaluate_agglomerate(dealii::Vector<double> const & /*src*/,
                                    dealii::Vector<double> & /*dst*/) const
@@ -57,6 +87,9 @@ public:
     ASSERT_THROW_NOT_IMPLEMENTED();
   }
 
+  /**
+   * Return the diagonal of the matrix the agglomerate operator conrresponds to.
+   */
   virtual std::vector<double> matrix_free_get_agglomerate_diagonal(
       dealii::AffineConstraints<double> & /*constraints*/) const
   {
@@ -65,6 +98,9 @@ public:
     return std::vector<double>();
   }
 
+  /**
+   *  Evaluate the operator on the global mesh.
+   */
   virtual void matrix_free_evaluate_global(
       dealii::LinearAlgebra::distributed::Vector<double> const & /*src*/,
       dealii::LinearAlgebra::distributed::Vector<double> & /*dst*/) const
@@ -72,6 +108,10 @@ public:
     ASSERT_THROW_NOT_IMPLEMENTED();
   }
 
+  /**
+   * Return the inverse of the diagonal of the matrix the global operator
+   * corresponds to. Constrained degrees of freedom are set to zero.
+   */
   virtual std::shared_ptr<dealii::DiagonalMatrix<
       dealii::LinearAlgebra::distributed::Vector<double>>>
   matrix_free_get_diagonal_inverse() const
@@ -81,6 +121,10 @@ public:
     return nullptr;
   }
 
+  /**
+   * Return the diagonal of the matrix the global operator corresponds to.
+   * Constrained degrees of freedom are set to zero.
+   */
   virtual dealii::LinearAlgebra::distributed::Vector<double>
   get_diagonal() override
   {

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -44,8 +44,8 @@ public:
 
   dealii::types::global_dof_index m() const;
 
-  virtual void
-  initialize_agglomerate(dealii::DoFHandler<dim> & /*dof_handler*/) const
+  virtual void matrix_free_initialize_agglomerate(
+      dealii::DoFHandler<dim> & /*dof_handler*/) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
   }

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -45,15 +45,19 @@ public:
   dealii::types::global_dof_index m() const;
 
   virtual void
-  matrix_free_evaluate_agglomerate(dealii::DoFHandler<dim> & /*dof_handler*/,
-                                   dealii::Vector<double> const & /*src*/,
+  initialize_agglomerate(dealii::DoFHandler<dim> & /*dof_handler*/) const
+  {
+    ASSERT_THROW_NOT_IMPLEMENTED();
+  }
+
+  virtual void
+  matrix_free_evaluate_agglomerate(dealii::Vector<double> const & /*src*/,
                                    dealii::Vector<double> & /*dst*/) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();
   }
 
   virtual std::vector<double> matrix_free_get_agglomerate_diagonal(
-      dealii::DoFHandler<dim> & /*dof_handler*/,
       dealii::AffineConstraints<double> & /*constraints*/) const
   {
     ASSERT_THROW_NOT_IMPLEMENTED();

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -186,8 +186,10 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
 
               // Perform the matrix-vector multiplication
               dealii::Vector<ScalarType> correction(n_elem);
+              dealii_mesh_evaluator->initialize_agglomerate(
+                  agglomerate_dof_handler);
               dealii_mesh_evaluator->matrix_free_evaluate_agglomerate(
-                  agglomerate_dof_handler, delta_eig, correction);
+                  delta_eig, correction);
 
               // We would like to fill the delta correction matrix but we can't
               // because we don't know the sparsity pattern. So we accumulate

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -186,7 +186,7 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
 
               // Perform the matrix-vector multiplication
               dealii::Vector<ScalarType> correction(n_elem);
-              dealii_mesh_evaluator->initialize_agglomerate(
+              dealii_mesh_evaluator->matrix_free_initialize_agglomerate(
                   agglomerate_dof_handler);
               dealii_mesh_evaluator->matrix_free_evaluate_agglomerate(
                   delta_eig, correction);

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -302,10 +302,6 @@ public:
     // Unfortunately, dealii::MatrixFreeOperators::Base only supports
     // dealii::LinearAlgebra::distributed::Vector so unless we duplicate a lot
     // of code, we need copy src and dst.
-    dealii::LinearAlgebra::distributed::Vector<ScalarType> distributed_dst(
-        dst.size());
-    dealii::LinearAlgebra::distributed::Vector<ScalarType> distributed_src(
-        src.size());
     std::copy(src.begin(), src.end(), distributed_src.begin());
     _agg_laplace_operator->vmult(distributed_dst, distributed_src);
     std::copy(distributed_dst.begin(), distributed_dst.end(), dst.begin());

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -342,8 +342,8 @@ public:
     return vector;
   }
 
-  virtual void
-  initialize_agglomerate(dealii::DoFHandler<dim> &dof_handler) const override
+  virtual void matrix_free_initialize_agglomerate(
+      dealii::DoFHandler<dim> &dof_handler) const override
   {
     // FIXME dof_handler should be const and initialized somewhere else
     dof_handler.distribute_dofs(_fe);

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -296,14 +296,9 @@ public:
   }
 
   virtual void
-  matrix_free_evaluate_agglomerate(dealii::DoFHandler<dim> &dof_handler,
-                                   dealii::Vector<double> const &src,
+  matrix_free_evaluate_agglomerate(dealii::Vector<double> const &src,
                                    dealii::Vector<double> &dst) const override
   {
-    // FIXME create a initialize function so that we don't need to do it
-    // everytime we need the diagonal or to do a vmult
-    initialize_matrix_free_agglomerate(dof_handler);
-
     // Unfortunately, dealii::MatrixFreeOperators::Base only supports
     // dealii::LinearAlgebra::distributed::Vector so unless we duplicate a lot
     // of code, we need copy src and dst.
@@ -317,13 +312,8 @@ public:
   }
 
   virtual std::vector<double> matrix_free_get_agglomerate_diagonal(
-      dealii::DoFHandler<dim> &dof_handler,
       dealii::AffineConstraints<double> &constraints) const override
   {
-    // FIXME create a initialize function so that we don't need to do it
-    // every time we need the diagonal or to do a vmult
-    initialize_matrix_free_agglomerate(dof_handler);
-
     constraints.copy_from(_agg_constraints);
 
     auto diag_matrix = _agg_laplace_operator->get_matrix_diagonal();
@@ -356,54 +346,59 @@ public:
     return vector;
   }
 
-private:
-  void initialize_matrix_free_agglomerate(
-      dealii::DoFHandler<dim> &dof_handler) const;
+  virtual void
+  initialize_agglomerate(dealii::DoFHandler<dim> &dof_handler) const override
+  {
+    // FIXME dof_handler should be const and initialized somewhere else
+    dof_handler.distribute_dofs(_fe);
 
+    dealii::IndexSet locally_relevant_dofs;
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
+                                                    locally_relevant_dofs);
+    // Compute the constraints
+    _agg_constraints.clear();
+    _agg_constraints.reinit(locally_relevant_dofs);
+    dealii::DoFTools::make_hanging_node_constraints(dof_handler,
+                                                    _agg_constraints);
+    dealii::VectorTools::interpolate_boundary_values(
+        dof_handler, 1, dealii::Functions::ZeroFunction<dim>(),
+        _agg_constraints);
+    _agg_constraints.close();
+
+    // Initialize the MatrixFree object
+    typename dealii::MatrixFree<dim, ScalarType>::AdditionalData
+        additional_data;
+    additional_data.tasks_parallel_scheme =
+        dealii::MatrixFree<dim, ScalarType>::AdditionalData::none;
+    additional_data.mapping_update_flags = dealii::update_gradients |
+                                           dealii::update_JxW_values |
+                                           dealii::update_quadrature_points;
+    std::shared_ptr<dealii::MatrixFree<dim, ScalarType>> mf_storage(
+        new dealii::MatrixFree<dim, ScalarType>());
+    mf_storage->reinit(dof_handler, _agg_constraints,
+                       dealii::QGauss<1>(fe_degree + 1), additional_data);
+
+    _agg_laplace_operator =
+        std::make_unique<LaplaceOperator<dim, fe_degree, ScalarType>>();
+    _agg_laplace_operator->initialize(mf_storage);
+    _agg_laplace_operator->evaluate_coefficient(*_material_property);
+    _agg_laplace_operator->compute_diagonal();
+
+    distributed_dst.reinit(dof_handler.n_dofs());
+    distributed_src.reinit(dof_handler.n_dofs());
+  }
+
+private:
   std::shared_ptr<Coefficient<dim>> _material_property;
   dealii::FE_Q<dim> _fe;
   mutable dealii::AffineConstraints<double> _agg_constraints;
   LaplaceOperator<dim, fe_degree, ScalarType> &_laplace_operator;
   mutable std::unique_ptr<LaplaceOperator<dim, fe_degree, ScalarType>>
       _agg_laplace_operator;
+  mutable dealii::LinearAlgebra::distributed::Vector<ScalarType>
+      distributed_dst;
+  mutable dealii::LinearAlgebra::distributed::Vector<ScalarType>
+      distributed_src;
 };
-
-template <int dim, int fe_degree, typename ScalarType>
-void TestMFMeshEvaluator<dim, fe_degree, ScalarType>::
-    initialize_matrix_free_agglomerate(
-        dealii::DoFHandler<dim> &dof_handler) const
-{
-  dof_handler.distribute_dofs(_fe);
-
-  dealii::IndexSet locally_relevant_dofs;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
-  // Compute the constraints
-  _agg_constraints.clear();
-  _agg_constraints.reinit(locally_relevant_dofs);
-  dealii::DoFTools::make_hanging_node_constraints(dof_handler,
-                                                  _agg_constraints);
-  dealii::VectorTools::interpolate_boundary_values(
-      dof_handler, 1, dealii::Functions::ZeroFunction<dim>(), _agg_constraints);
-  _agg_constraints.close();
-
-  // Initialize the MatrixFree object
-  typename dealii::MatrixFree<dim, ScalarType>::AdditionalData additional_data;
-  additional_data.tasks_parallel_scheme =
-      dealii::MatrixFree<dim, ScalarType>::AdditionalData::none;
-  additional_data.mapping_update_flags = dealii::update_gradients |
-                                         dealii::update_JxW_values |
-                                         dealii::update_quadrature_points;
-  std::shared_ptr<dealii::MatrixFree<dim, ScalarType>> mf_storage(
-      new dealii::MatrixFree<dim, ScalarType>());
-  mf_storage->reinit(dof_handler, _agg_constraints,
-                     dealii::QGauss<1>(fe_degree + 1), additional_data);
-
-  _agg_laplace_operator =
-      std::make_unique<LaplaceOperator<dim, fe_degree, ScalarType>>();
-  _agg_laplace_operator->initialize(mf_storage);
-  _agg_laplace_operator->evaluate_coefficient(*_material_property);
-  _agg_laplace_operator->compute_diagonal();
-}
 
 #endif // #ifdef MFMG_TEST_HIERARCHY_HELPERS_HPP


### PR DESCRIPTION
Previously, we were initializing the `MatrixFree` data structures in `TestMFMeshEvaluator` on each agglomerate evaluation, i.e. each time the eigensolver evaluated the operator, taking about 30% of the overall number of instructions. This is really wasteful since we only need to do this initialization once per agglomerate.
For the sake of avoiding to hunt down `cv` qualifiers through the entire library, `DealIIMatrixFreeMeshEvaluator` is `const` although we change internal data structures in a way that calling `matrix_free_evaluate_agglomerate` performs the evaluation on the correct patch. Since  the corresponding member variables have already been `mutable` before, this doesn't really change anything in terms of `const` correctness.