### PR TITLE
Avoid calculating the end iterator repeatedly

### DIFF
--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -244,8 +244,9 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
     auto const range_end = eigenvector_matrix->local_range().second;
     for (unsigned int row = range_start; row < range_end; ++row)
     {
+      auto const end_iterator = eigenvector_matrix->end(row);
       for (auto column_iterator = eigenvector_matrix->begin(row);
-           column_iterator != eigenvector_matrix->end(row); ++column_iterator)
+           column_iterator != end_iterator; ++column_iterator)
       {
         column_iterator->value() *= eigenvalues.at(row - range_start);
       }

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -238,8 +238,9 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     auto const range_end = eigenvector_matrix->local_range().second;
     for (unsigned int row = range_start; row < range_end; ++row)
     {
+      auto const end_iterator = eigenvector_matrix->end(row);
       for (auto column_iterator = eigenvector_matrix->begin(row);
-           column_iterator != eigenvector_matrix->end(row); ++column_iterator)
+           column_iterator != end_iterator; ++column_iterator)
       {
         column_iterator->value() *= eigenvalues.at(row - range_start);
       }


### PR DESCRIPTION
It turned out that calculating the row end iterator for `TrilinosWrappers::SparseMatrix` objects is really expensive. Storing it instead cuts down the run time for matrix-free runs with `FastAP` by a factor 4-7.