### PR TITLE
Improve memory consumption

### DIFF
--- a/include/mfmg/common/amge.templates.hpp
+++ b/include/mfmg/common/amge.templates.hpp
@@ -179,13 +179,16 @@ void AMGe<dim, VectorType>::build_agglomerate_triangulation(
   std::vector<typename dealii::DoFHandler<dim>::active_cell_iterator>
       agglomerate;
   auto cell = _dof_handler.begin_active();
-  std::advance(cell, cell_index[0]);
-  agglomerate.push_back(cell);
-
-  for (unsigned int i = 1; i < cell_index.size(); ++i)
+  if (cell_index.size() > 0)
   {
-    std::advance(cell, cell_index[i] - cell_index[i - 1]);
+    std::advance(cell, cell_index[0]);
     agglomerate.push_back(cell);
+
+    for (unsigned int i = 1; i < cell_index.size(); ++i)
+    {
+      std::advance(cell, cell_index[i] - cell_index[i - 1]);
+      agglomerate.push_back(cell);
+    }
   }
 
   build_agglomerate_triangulation(agglomerate, agglomerate_triangulation,

--- a/include/mfmg/common/amge.templates.hpp
+++ b/include/mfmg/common/amge.templates.hpp
@@ -178,9 +178,10 @@ void AMGe<dim, VectorType>::build_agglomerate_triangulation(
 {
   std::vector<typename dealii::DoFHandler<dim>::active_cell_iterator>
       agglomerate;
-  auto cell = _dof_handler.begin_active();
+  agglomerate.reserve(cell_index.size());
   if (cell_index.size() > 0)
   {
+    auto cell = _dof_handler.begin_active();
     std::advance(cell, cell_index[0]);
     agglomerate.push_back(cell);
 

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -237,7 +237,7 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
     // Scale the eigenvectors by their corresponding eigenvalues.
     // It turned out that accessing the individual matrix entries through the
     // deal.II TrilinosWrapper::SparseMatrix::begin() interface is much slower
-    // than constucting a representation of the eigenvalues as
+    // than constructing a representation of the eigenvalues as
     // Epetra_MultiVector and calling a Epetra_CrsMatrix member function.
     auto const range_start = eigenvector_matrix->local_range().first;
     auto const range_end = eigenvector_matrix->local_range().second;

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -122,8 +122,8 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
       } scratch_data;
       struct CopyData
       {
-        std::vector<unsigned int> rows;
-        std::vector<unsigned int> cols;
+        std::vector<dealii::types::global_dof_index> rows;
+        std::vector<dealii::types::global_dof_index> cols;
         std::vector<std::vector<dealii::TrilinosScalar>> values_per_row;
       } copy_data;
 

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -294,14 +294,6 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
 }
 
 template <int dim, typename VectorType>
-std::shared_ptr<Operator<VectorType>>
-DealIIHierarchyHelpers<dim, VectorType>::fast_multiply_transpose()
-{
-
-  return _ap_operator;
-}
-
-template <int dim, typename VectorType>
 std::shared_ptr<Smoother<VectorType>>
 DealIIHierarchyHelpers<dim, VectorType>::build_smoother(
     std::shared_ptr<Operator<VectorType> const> op,
@@ -318,6 +310,14 @@ DealIIHierarchyHelpers<dim, VectorType>::build_coarse_solver(
 {
   return std::make_shared<DealIISolver<VectorType>>(op, params);
 }
+
+template <int dim, typename VectorType>
+std::shared_ptr<Operator<VectorType>>
+DealIIHierarchyHelpers<dim, VectorType>::fast_multiply_transpose()
+{
+  return _ap_operator;
+}
+
 } // namespace mfmg
 
 // Explicit Instantiation

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -164,6 +164,9 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
             auto const &dof_indices_map = local_copy_data.cols;
             unsigned int const n_elem = dof_indices_map.size();
 
+            // We need a clean reset for the values we are going to store.
+            // Otherwise, we would accumulate values across patches
+            // corresponding to different degrees of freedom.
             local_copy_data.values_per_row.resize(n_local_eigenvectors);
             std::fill(local_copy_data.values_per_row.begin(),
                       local_copy_data.values_per_row.end(),

--- a/source/dealii/dealii_hierarchy_helpers.cc
+++ b/source/dealii/dealii_hierarchy_helpers.cc
@@ -122,17 +122,15 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
       } scratch_data;
       struct CopyData
       {
-        std::unordered_map<std::pair<unsigned int, unsigned int>, double,
-                           boost::hash<std::pair<unsigned int, unsigned int>>>
-            delta_correction_local_acc;
+        std::vector<unsigned int> rows;
+        std::vector<unsigned int> cols;
+        std::vector<std::vector<dealii::TrilinosScalar>> values_per_row;
       } copy_data;
 
       auto worker =
           [&](const std::vector<std::vector<unsigned int>>::const_iterator
                   &agglomerate_it,
               ScratchData &, CopyData &local_copy_data) {
-            local_copy_data.delta_correction_local_acc.clear();
-
             dealii::Triangulation<dim> agglomerate_triangulation;
             std::map<typename dealii::Triangulation<dim>::active_cell_iterator,
                      typename dealii::DoFHandler<dim>::active_cell_iterator>
@@ -159,11 +157,20 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
 
             // Put the result in the matrix
             // Compute the map between the local and the global dof indices.
-            std::vector<dealii::types::global_dof_index> dof_indices_map =
-                amge.compute_dof_index_map(patch_to_global_map,
-                                           agglomerate_dof_handler);
+            local_copy_data.rows.resize(n_local_eigenvectors);
+
+            local_copy_data.cols = amge.compute_dof_index_map(
+                patch_to_global_map, agglomerate_dof_handler);
+            auto const &dof_indices_map = local_copy_data.cols;
             unsigned int const n_elem = dof_indices_map.size();
+
+            local_copy_data.values_per_row.resize(n_local_eigenvectors);
+            std::fill(local_copy_data.values_per_row.begin(),
+                      local_copy_data.values_per_row.end(),
+                      std::vector<dealii::TrilinosScalar>(n_elem));
+
             unsigned int const i = agglomerate_it - agglomerates_vector.begin();
+
             for (unsigned int j = 0; j < n_local_eigenvectors; ++j)
             {
               unsigned int const local_row = i * n_local_eigenvectors + j;
@@ -195,23 +202,25 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
               dealii::Vector<ScalarType> correction(n_elem);
               agglomerate_system_matrix.vmult(correction, delta_eig);
 
-              // We would like to fill the delta correction matrix but we can't
-              // because we don't know the sparsity pattern. So we accumulate
-              // all the values and then fill the matrix using the set()
-              // function.
-              for (unsigned int k = 0; k < n_elem; ++k)
-              {
-                local_copy_data.delta_correction_local_acc[std::make_pair(
-                    global_row, dof_indices_map[k])] += correction[k];
-              }
+              // Store the values the delta correction matrix is to be filled
+              // with.
+              local_copy_data.rows[j] = global_row;
+              std::transform(correction.begin(), correction.end(),
+                             local_copy_data.values_per_row[j].begin(),
+                             local_copy_data.values_per_row[j].begin(),
+                             std::plus<double>());
             }
           };
 
       auto copier = [&](const CopyData &local_copy_data) {
-        for (const auto &local_pair :
-             local_copy_data.delta_correction_local_acc)
+        for (unsigned int i = 0; i < local_copy_data.rows.size(); ++i)
         {
-          delta_correction_acc[local_pair.first] += local_pair.second;
+          // Since we didn't provide a sparsity pattern this "set" operation
+          // actually acts as an "add" operation until "compress" is called.
+          delta_correction_matrix.set(
+              local_copy_data.rows[i], local_copy_data.cols.size(),
+              local_copy_data.cols.data(),
+              local_copy_data.values_per_row[i].data(), true);
         }
       };
 
@@ -223,12 +232,27 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
     }
 
     // Fill delta_correction_matrix
-    for (auto const &entry : delta_correction_acc)
-    {
-      delta_correction_matrix.set(entry.first.first, entry.first.second,
-                                  entry.second);
-    }
     delta_correction_matrix.compress(dealii::VectorOperation::insert);
+
+    auto const range_start = eigenvector_matrix->local_range().first;
+    auto const range_end = eigenvector_matrix->local_range().second;
+
+    dealii::IndexSet locally_owned_elements(eigenvector_matrix->m());
+    locally_owned_elements.add_range(range_start, range_end);
+    dealii::TrilinosWrappers::MPI::Vector vector_eigenvalues(
+        locally_owned_elements, comm);
+    std::vector<unsigned int> local_indices(eigenvalues.size());
+    std::iota(local_indices.begin(), local_indices.end(), range_start);
+    vector_eigenvalues.set(local_indices, eigenvalues);
+    vector_eigenvalues.compress(dealii::VectorOperation::insert);
+
+    Epetra_MultiVector &dummy_multi_vector =
+        vector_eigenvalues.trilinos_vector();
+    auto &dummy_matrix =
+        const_cast<Epetra_CrsMatrix &>(eigenvector_matrix->trilinos_matrix());
+    dummy_matrix.LeftScale(*dummy_multi_vector(0));
+
+    eigenvector_matrix->compress(dealii::VectorOperation::insert);
 
     // Add the eigenvector matrix and the delta correction matrix to create ap
     Epetra_CrsMatrix *ap = nullptr;
@@ -239,26 +263,11 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
     Epetra_Map range_map = eigenvector_matrix->domain_partitioner();
     Epetra_Map domain_map = eigenvector_matrix->range_partitioner();
 #pragma GCC diagnostic pop
-
-    auto const range_start = eigenvector_matrix->local_range().first;
-    auto const range_end = eigenvector_matrix->local_range().second;
-    for (unsigned int row = range_start; row < range_end; ++row)
-    {
-      auto const end_iterator = eigenvector_matrix->end(row);
-      for (auto column_iterator = eigenvector_matrix->begin(row);
-           column_iterator != end_iterator; ++column_iterator)
-      {
-        column_iterator->value() *= eigenvalues.at(row - range_start);
-      }
-    }
-    eigenvector_matrix->compress(dealii::VectorOperation::insert);
-
     bool const transpose = true;
     int error_code = EpetraExt::MatrixMatrix::Add(
         eigenvector_matrix->trilinos_matrix(), transpose, 1.,
         delta_correction_matrix.trilinos_matrix(), transpose, 1., ap);
     ap->FillComplete(domain_map, range_map);
-
     ASSERT(error_code == 0, "Problem when adding matrices");
 
     // Copy the Epetra_CrsMatrix to a dealii::TrilinosWrappers::SparseMatrix
@@ -272,6 +281,7 @@ DealIIHierarchyHelpers<dim, VectorType>::build_restrictor(
   {
     AMGe_host<dim, DealIIMeshEvaluator<dim>, VectorType> amge(
         comm, dealii_mesh_evaluator->get_dof_handler(), eigensolver_params);
+
     amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
                           *dealii_mesh_evaluator, locally_relevant_global_diag,
                           *restrictor_matrix);

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -157,6 +157,9 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
             auto const &dof_indices_map = local_copy_data.cols;
             unsigned int const n_elem = dof_indices_map.size();
 
+            // We need a clean reset for the values we are going to store.
+            // Otherwise, we would accumulate values across patches
+            // corresponding to different degrees of freedom.
             local_copy_data.values_per_row.resize(n_local_eigenvectors);
             std::fill(local_copy_data.values_per_row.begin(),
                       local_copy_data.values_per_row.end(),

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -233,7 +233,7 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     // Scale the eigenvectors by their corresponding eigenvalues.
     // It turned out that accessing the individual matrix entries through the
     // deal.II TrilinosWrapper::SparseMatrix::begin() interface is much slower
-    // than constucting a representation of the eigenvalues as
+    // than constructing a representation of the eigenvalues as
     // Epetra_MultiVector and calling a Epetra_CrsMatrix member function.
     auto const range_start = eigenvector_matrix->local_range().first;
     auto const range_end = eigenvector_matrix->local_range().second;

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -230,6 +230,11 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     // Fill delta_correction_matrix
     delta_correction_matrix.compress(dealii::VectorOperation::insert);
 
+    // Scale the eigenvectors by their corresponding eigenvalues.
+    // It turned out that accessing the individual matrix entries through the
+    // deal.II TrilinosWrapper::SparseMatrix::begin() interface is much slower
+    // than constucting a representation of the eigenvalues as
+    // Epetra_MultiVector and calling a Epetra_CrsMatrix member function.
     auto const range_start = eigenvector_matrix->local_range().first;
     auto const range_end = eigenvector_matrix->local_range().second;
 
@@ -237,7 +242,8 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     locally_owned_elements.add_range(range_start, range_end);
     dealii::TrilinosWrappers::MPI::Vector vector_eigenvalues(
         locally_owned_elements, comm);
-    std::vector<unsigned int> local_indices(eigenvalues.size());
+    std::vector<dealii::types::global_dof_index> local_indices(
+        eigenvalues.size());
     std::iota(local_indices.begin(), local_indices.end(), range_start);
     vector_eigenvalues.set(local_indices, eigenvalues);
     vector_eigenvalues.compress(dealii::VectorOperation::insert);

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -120,17 +120,15 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
       } scratch_data;
       struct CopyData
       {
-        std::unordered_map<std::pair<unsigned int, unsigned int>, double,
-                           boost::hash<std::pair<unsigned int, unsigned int>>>
-            delta_correction_local_acc;
+        std::vector<unsigned int> rows;
+        std::vector<unsigned int> cols;
+        std::vector<std::vector<dealii::TrilinosScalar>> values_per_row;
       } copy_data;
 
       auto worker =
           [&](const std::vector<std::vector<unsigned int>>::const_iterator
                   &agglomerate_it,
               ScratchData &, CopyData &local_copy_data) {
-            local_copy_data.delta_correction_local_acc.clear();
-
             dealii::Triangulation<dim> agglomerate_triangulation;
             std::map<typename dealii::Triangulation<dim>::active_cell_iterator,
                      typename dealii::DoFHandler<dim>::active_cell_iterator>
@@ -152,11 +150,20 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
 
             // Put the result in the matrix
             // Compute the map between the local and the global dof indices.
-            std::vector<dealii::types::global_dof_index> dof_indices_map =
-                amge.compute_dof_index_map(patch_to_global_map,
-                                           agglomerate_dof_handler);
+            local_copy_data.rows.resize(n_local_eigenvectors);
+
+            local_copy_data.cols = amge.compute_dof_index_map(
+                patch_to_global_map, agglomerate_dof_handler);
+            auto const &dof_indices_map = local_copy_data.cols;
             unsigned int const n_elem = dof_indices_map.size();
+
+            local_copy_data.values_per_row.resize(n_local_eigenvectors);
+            std::fill(local_copy_data.values_per_row.begin(),
+                      local_copy_data.values_per_row.end(),
+                      std::vector<dealii::TrilinosScalar>(n_elem));
+
             unsigned int const i = agglomerate_it - agglomerates_vector.begin();
+
             for (unsigned int j = 0; j < n_local_eigenvectors; ++j)
             {
               unsigned int const local_row = i * n_local_eigenvectors + j;
@@ -191,23 +198,25 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
               dealii_mesh_evaluator->matrix_free_evaluate_agglomerate(
                   delta_eig, correction);
 
-              // We would like to fill the delta correction matrix but we can't
-              // because we don't know the sparsity pattern. So we accumulate
-              // all the values and then fill the matrix using the set()
-              // function.
-              for (unsigned int k = 0; k < n_elem; ++k)
-              {
-                local_copy_data.delta_correction_local_acc[std::make_pair(
-                    global_row, dof_indices_map[k])] += correction[k];
-              }
+              // Store the values the delta correction matrix is to be filled
+              // with.
+              local_copy_data.rows[j] = global_row;
+              std::transform(correction.begin(), correction.end(),
+                             local_copy_data.values_per_row[j].begin(),
+                             local_copy_data.values_per_row[j].begin(),
+                             std::plus<double>());
             }
           };
 
       auto copier = [&](const CopyData &local_copy_data) {
-        for (const auto &local_pair :
-             local_copy_data.delta_correction_local_acc)
+        for (unsigned int i = 0; i < local_copy_data.rows.size(); ++i)
         {
-          delta_correction_acc[local_pair.first] += local_pair.second;
+          // Since we didn't provide a sparsity pattern this "set" operation
+          // actually acts as an "add" operation until "compress" is called.
+          delta_correction_matrix.set(
+              local_copy_data.rows[i], local_copy_data.cols.size(),
+              local_copy_data.cols.data(),
+              local_copy_data.values_per_row[i].data(), true);
         }
       };
 
@@ -219,12 +228,27 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     }
 
     // Fill delta_correction_matrix
-    for (auto const &entry : delta_correction_acc)
-    {
-      delta_correction_matrix.set(entry.first.first, entry.first.second,
-                                  entry.second);
-    }
     delta_correction_matrix.compress(dealii::VectorOperation::insert);
+
+    auto const range_start = eigenvector_matrix->local_range().first;
+    auto const range_end = eigenvector_matrix->local_range().second;
+
+    dealii::IndexSet locally_owned_elements(eigenvector_matrix->m());
+    locally_owned_elements.add_range(range_start, range_end);
+    dealii::TrilinosWrappers::MPI::Vector vector_eigenvalues(
+        locally_owned_elements, comm);
+    std::vector<unsigned int> local_indices(eigenvalues.size());
+    std::iota(local_indices.begin(), local_indices.end(), range_start);
+    vector_eigenvalues.set(local_indices, eigenvalues);
+    vector_eigenvalues.compress(dealii::VectorOperation::insert);
+
+    Epetra_MultiVector &dummy_multi_vector =
+        vector_eigenvalues.trilinos_vector();
+    auto &dummy_matrix =
+        const_cast<Epetra_CrsMatrix &>(eigenvector_matrix->trilinos_matrix());
+    dummy_matrix.LeftScale(*dummy_multi_vector(0));
+
+    eigenvector_matrix->compress(dealii::VectorOperation::insert);
 
     // Add the eigenvector matrix and the delta correction matrix to create ap
     Epetra_CrsMatrix *ap = nullptr;
@@ -235,20 +259,6 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     Epetra_Map range_map = eigenvector_matrix->domain_partitioner();
     Epetra_Map domain_map = eigenvector_matrix->range_partitioner();
 #pragma GCC diagnostic pop
-
-    auto const range_start = eigenvector_matrix->local_range().first;
-    auto const range_end = eigenvector_matrix->local_range().second;
-    for (unsigned int row = range_start; row < range_end; ++row)
-    {
-      auto const end_iterator = eigenvector_matrix->end(row);
-      for (auto column_iterator = eigenvector_matrix->begin(row);
-           column_iterator != end_iterator; ++column_iterator)
-      {
-        column_iterator->value() *= eigenvalues.at(row - range_start);
-      }
-    }
-    eigenvector_matrix->compress(dealii::VectorOperation::insert);
-
     bool const transpose = true;
     int error_code = EpetraExt::MatrixMatrix::Add(
         eigenvector_matrix->trilinos_matrix(), transpose, 1.,

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -120,8 +120,8 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
       } scratch_data;
       struct CopyData
       {
-        std::vector<unsigned int> rows;
-        std::vector<unsigned int> cols;
+        std::vector<dealii::types::global_dof_index> rows;
+        std::vector<dealii::types::global_dof_index> cols;
         std::vector<std::vector<dealii::TrilinosScalar>> values_per_row;
       } copy_data;
 


### PR DESCRIPTION
This is the run time profile I see with the changes:
```
Time before setup_restrictor: 0.301192 s
Time before delta_correction: 8.06771 s
...
Time before using agglomerates: 8.09335 s
Time before filling delta_correction: 11.8859 s
Time after compressing: 12.0269 s
Time after rescaling: 23.0697 s
...
Converging after 52 iterations.
```
and these are the old ones:
```
Time before setup_restrictor: 0.325443 s
Time before delta_correction: 8.5101 s
...
Time before using agglomerates: 8.53592 s
Time before filling delta_correction: 13.6987 s
Time after compressing: 14.6252 s
Time after rescaling: 17.4326 s
...
Converging after 52 iterations.
```
The corresponding `callgrind` shows less instructions with the changes, though.
New:
![memprofile_new](https://user-images.githubusercontent.com/2423533/58350944-5c64ff00-7e35-11e9-8aef-1f31ad101153.png)
Old:
![memprofile_old](https://user-images.githubusercontent.com/2423533/58350945-5c64ff00-7e35-11e9-88a5-0a9a9d181b39.png)

So we are using 70MB (~30%) less.

The part that is slower after these changes is:
```c++
    auto const range_start = eigenvector_matrix->local_range().first;
    auto const range_end = eigenvector_matrix->local_range().second;
    for (unsigned int row = range_start; row < range_end; ++row)
    {
      auto const end_iterator = eigenvector_matrix->end(row);
      for (auto column_iterator = eigenvector_matrix->begin(row);
           column_iterator != end_iterator; ++column_iterator)
      {
        column_iterator->value() *= eigenvalues[row - range_start];
      }
    }
```
which looks totally unrelated to the changes made. The memory profile indicates that we allocate and deallocate a lot here. This would at least be consistent with the `valgrind` output being better with the changes.

