### PR TITLE
Provide virtual destructors to all polymorphic classes

### DIFF
--- a/include/mfmg/common/exceptions.hpp
+++ b/include/mfmg/common/exceptions.hpp
@@ -64,6 +64,10 @@ inline void ASSERT_THROW(bool cond, std::string const &message)
 
 class NotImplementedExc : public std::exception
 {
+public:
+  virtual ~NotImplementedExc() override = default;
+
+private:
   virtual const char *what() const throw() final override
   {
     return "The function is not implemented";

--- a/include/mfmg/common/hierarchy_helpers.hpp
+++ b/include/mfmg/common/hierarchy_helpers.hpp
@@ -32,6 +32,8 @@ class HierarchyHelpers
 public:
   using vector_type = VectorType;
 
+  virtual ~HierarchyHelpers() = default;
+
   virtual std::shared_ptr<Operator<vector_type>>
   get_global_operator(std::shared_ptr<MeshEvaluator> mesh_evaluator) = 0;
 

--- a/include/mfmg/common/mesh_evaluator.hpp
+++ b/include/mfmg/common/mesh_evaluator.hpp
@@ -19,6 +19,8 @@ namespace mfmg
 class MeshEvaluator
 {
 public:
+  virtual ~MeshEvaluator() = default;
+
   virtual int get_dim() const = 0;
 
   virtual std::string get_mesh_evaluator_type() const = 0;

--- a/include/mfmg/cuda/cuda_hierarchy_helpers.cuh
+++ b/include/mfmg/cuda/cuda_hierarchy_helpers.cuh
@@ -27,6 +27,8 @@ public:
 
   CudaHierarchyHelpers(CudaHandle const &cuda_handle);
 
+  virtual ~CudaHierarchyHelpers() override = default;
+
   std::shared_ptr<Operator<vector_type>> get_global_operator(
       std::shared_ptr<MeshEvaluator> mesh_evaluator) override final;
 

--- a/include/mfmg/cuda/cuda_matrix_operator.cuh
+++ b/include/mfmg/cuda/cuda_matrix_operator.cuh
@@ -29,6 +29,8 @@ public:
   CudaMatrixOperator(
       std::shared_ptr<SparseMatrixDevice<value_type>> sparse_matrix);
 
+  virtual ~CudaMatrixOperator() override = default;
+
   void apply(vector_type const &x, vector_type &y,
              OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 

--- a/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
+++ b/include/mfmg/dealii/dealii_hierarchy_helpers.hpp
@@ -25,6 +25,8 @@ public:
   using vector_type = VectorType;
   using ScalarType = typename VectorType::value_type;
 
+  virtual ~DealIIHierarchyHelpers() override = default;
+
   std::shared_ptr<Operator<vector_type>> get_global_operator(
       std::shared_ptr<MeshEvaluator> mesh_evaluator) override final;
 

--- a/include/mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp
@@ -23,6 +23,8 @@ public:
   using vector_type = VectorType;
   using ScalarType = typename VectorType::value_type;
 
+  virtual ~DealIIMatrixFreeHierarchyHelpers() override = default;
+
   std::shared_ptr<Operator<vector_type>> get_global_operator(
       std::shared_ptr<MeshEvaluator> mesh_evaluator) override final;
 

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -52,6 +52,11 @@ public:
                                 dealii::AffineConstraints<double> &constraints);
 
   /**
+   * Destructor.
+   */
+  virtual ~DealIIMatrixFreeMeshEvaluator() override = default;
+
+  /**
    * Return the class name as std::string.
    */
   std::string get_mesh_evaluator_type() const override final;

--- a/include/mfmg/dealii/dealii_matrix_free_operator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_operator.hpp
@@ -36,6 +36,8 @@ public:
   DealIIMatrixFreeOperator(std::shared_ptr<DealIIMatrixFreeMeshEvaluator<dim>>
                                matrix_free_mesh_evaluator);
 
+  virtual ~DealIIMatrixFreeOperator() override = default;
+
   void apply(vector_type const &x, vector_type &y,
              OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 

--- a/include/mfmg/dealii/dealii_matrix_free_smoother.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_smoother.hpp
@@ -39,6 +39,8 @@ public:
       std::shared_ptr<Operator<vector_type> const> op,
       std::shared_ptr<boost::property_tree::ptree const> params);
 
+  virtual ~DealIIMatrixFreeSmoother() override = default;
+
   void apply(vector_type const &b, vector_type &x) const override;
 
 private:

--- a/include/mfmg/dealii/dealii_matrix_operator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_operator.hpp
@@ -31,6 +31,8 @@ public:
       std::shared_ptr<dealii::SparseMatrix<typename VectorType::value_type>>
           sparse_matrix);
 
+  virtual ~DealIIMatrixOperator() override = default;
+
   void apply(vector_type const &x, vector_type &y,
              OperatorMode mode = OperatorMode::NO_TRANS) const override final;
 

--- a/include/mfmg/dealii/dealii_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_mesh_evaluator.hpp
@@ -29,8 +29,11 @@ public:
   DealIIMeshEvaluator(dealii::DoFHandler<dim> &dof_handler,
                       dealii::AffineConstraints<double> &constraints);
 
+  virtual ~DealIIMeshEvaluator() override = default;
+
   static int constexpr _dim = dim;
-  int get_dim() const override final;
+
+  virtual int get_dim() const override final;
 
   std::string get_mesh_evaluator_type() const override /*final*/;
 

--- a/include/mfmg/dealii/dealii_smoother.hpp
+++ b/include/mfmg/dealii/dealii_smoother.hpp
@@ -32,6 +32,8 @@ public:
   DealIISmoother(std::shared_ptr<Operator<vector_type> const> op,
                  std::shared_ptr<boost::property_tree::ptree const> params);
 
+  virtual ~DealIISmoother() override = default;
+
   void apply(vector_type const &b, vector_type &x) const override final;
 
 private:

--- a/include/mfmg/dealii/dealii_solver.hpp
+++ b/include/mfmg/dealii/dealii_solver.hpp
@@ -27,6 +27,8 @@ public:
   DealIISolver(std::shared_ptr<Operator<vector_type> const> op,
                std::shared_ptr<boost::property_tree::ptree const> params);
 
+  virtual ~DealIISolver() override = default;
+
   void apply(vector_type const &b, vector_type &x) const override;
 
 private:

--- a/include/mfmg/dealii/dealii_trilinos_matrix_operator.hpp
+++ b/include/mfmg/dealii/dealii_trilinos_matrix_operator.hpp
@@ -27,6 +27,8 @@ public:
   DealIITrilinosMatrixOperator(
       std::shared_ptr<dealii::TrilinosWrappers::SparseMatrix> sparse_matrix);
 
+  virtual ~DealIITrilinosMatrixOperator() override = default;
+
   void apply(vector_type const &x, vector_type &y,
              OperatorMode mode = OperatorMode::NO_TRANS) const override;
 

--- a/tests/laplace_matrix_free.hpp
+++ b/tests/laplace_matrix_free.hpp
@@ -37,6 +37,8 @@ public:
 
   LaplaceOperator();
 
+  virtual ~LaplaceOperator() override = default;
+
   virtual void compute_diagonal() override final;
 
   template <typename MaterialPropertyType>

--- a/tests/test_eigenvectors.cc
+++ b/tests/test_eigenvectors.cc
@@ -37,6 +37,8 @@ public:
   {
   }
 
+  virtual ~DiagonalTestMeshEvaluator() override = default;
+
   // Diagonal matrices. We only need local evaluate function.
   void evaluate_agglomerate(
       dealii::DoFHandler<dim> &dof_handler,
@@ -135,6 +137,8 @@ public:
       : mfmg::DealIIMeshEvaluator<dim>(dof_handler, constraints)
   {
   }
+
+  virtual ~ConstrainedDiagonalTestMeshEvaluator() override = default;
 
   // Diagonal matrices. We only need local evaluate function.
   void evaluate_agglomerate(

--- a/tests/test_eigenvectors_device.cu
+++ b/tests/test_eigenvectors_device.cu
@@ -35,6 +35,8 @@ public:
   {
   }
 
+  virtual ~DiagonalTestMeshEvaluator() override = default;
+
   void evaluate_agglomerate(
       dealii::DoFHandler<2> &dof_handler,
       dealii::AffineConstraints<double> &constraint_matrix,

--- a/tests/test_hierarchy_device.cu
+++ b/tests/test_hierarchy_device.cu
@@ -29,6 +29,8 @@ class Source : public dealii::Function<dim>
 public:
   Source() = default;
 
+  virtual ~Source() override = default;
+
   virtual double value(dealii::Point<dim> const &,
                        unsigned int const = 0) const override final
   {
@@ -41,6 +43,8 @@ class ConstantMaterialProperty : public dealii::Function<dim>
 {
 public:
   ConstantMaterialProperty() = default;
+
+  virtual ~ConstantMaterialProperty() override = default;
 
   virtual double value(dealii::Point<dim> const &,
                        unsigned int const = 0) const override final
@@ -55,6 +59,8 @@ class LinearXMaterialProperty : public dealii::Function<dim>
 public:
   LinearXMaterialProperty() = default;
 
+  virtual ~LinearXMaterialProperty() override = default;
+
   virtual double value(dealii::Point<dim> const &p,
                        unsigned int const = 0) const override final
   {
@@ -67,6 +73,8 @@ class LinearMaterialProperty : public dealii::Function<dim>
 {
 public:
   LinearMaterialProperty() = default;
+
+  virtual ~LinearMaterialProperty() override = default;
 
   virtual double value(dealii::Point<dim> const &p,
                        unsigned int const = 0) const override final
@@ -84,6 +92,8 @@ class DiscontinuousMaterialProperty : public dealii::Function<dim>
 {
 public:
   DiscontinuousMaterialProperty() = default;
+
+  virtual ~DiscontinuousMaterialProperty() override = default;
 
   virtual double value(dealii::Point<dim> const &p,
                        unsigned int const = 0) const override final
@@ -137,6 +147,8 @@ public:
         _material_property(material_property)
   {
   }
+
+  virtual ~TestMeshEvaluator() override = default;
 
   virtual dealii::LinearAlgebra::distributed::Vector<double>
   get_locally_relevant_diag() const override final

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -43,6 +43,8 @@ class Source final : public dealii::Function<dim>
 public:
   Source() = default;
 
+  virtual ~Source() override = default;
+
   virtual double value(dealii::Point<dim> const &,
                        unsigned int const = 0) const override
   {
@@ -54,6 +56,8 @@ template <int dim>
 class Coefficient : public dealii::Function<dim>
 {
 public:
+  virtual ~Coefficient() override = default;
+
   virtual dealii::VectorizedArray<double>
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &p,
         unsigned int const = 0) const = 0;
@@ -67,6 +71,8 @@ class ConstantMaterialProperty final : public Coefficient<dim>
 {
 public:
   ConstantMaterialProperty() = default;
+
+  virtual ~ConstantMaterialProperty() override = default;
 
   virtual dealii::VectorizedArray<double>
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &,
@@ -88,6 +94,8 @@ class LinearXMaterialProperty final : public Coefficient<dim>
 public:
   LinearXMaterialProperty() = default;
 
+  virtual ~LinearXMaterialProperty() override = default;
+
   virtual dealii::VectorizedArray<double>
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &p,
         unsigned int const = 0) const override
@@ -108,6 +116,8 @@ class LinearMaterialProperty final : public Coefficient<dim>
 {
 public:
   LinearMaterialProperty() = default;
+
+  virtual ~LinearMaterialProperty() override = default;
 
   virtual dealii::VectorizedArray<double>
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &p,
@@ -137,6 +147,8 @@ class DiscontinuousMaterialProperty final : public Coefficient<dim>
 {
 public:
   DiscontinuousMaterialProperty() = default;
+
+  virtual ~DiscontinuousMaterialProperty() override = default;
 
   virtual dealii::VectorizedArray<double>
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &p,
@@ -200,6 +212,8 @@ public:
         _matrix(matrix), _material_property(material_property)
   {
   }
+
+  virtual ~TestMeshEvaluator() override = default;
 
   virtual void evaluate_global(
       dealii::DoFHandler<dim> &, dealii::AffineConstraints<double> &,
@@ -294,6 +308,8 @@ public:
         _laplace_operator(laplace_operator)
   {
   }
+
+  virtual ~TestMFMeshEvaluator() override = default;
 
   virtual void
   matrix_free_evaluate_agglomerate(dealii::Vector<double> const &src,

--- a/tests/test_laplace.cc
+++ b/tests/test_laplace.cc
@@ -26,6 +26,8 @@ class ExactSolution : public dealii::Function<dim>
 public:
   ExactSolution() = default;
 
+  virtual ~ExactSolution() override = default;
+
   double value(dealii::Point<dim> const &p,
                unsigned int const component = 0) const override;
 };
@@ -46,6 +48,8 @@ class Source : public dealii::Function<dim>
 {
 public:
   Source() = default;
+
+  virtual ~Source() override = default;
 
   double value(dealii::Point<dim> const &p,
                unsigned int const component = 0) const override;
@@ -73,6 +77,8 @@ class MaterialProperty : public dealii::Function<dim>
 {
 public:
   MaterialProperty() = default;
+
+  virtual ~MaterialProperty() override = default;
 
   double value(dealii::Point<dim> const &p,
                unsigned int const component = 0) const override;

--- a/tests/test_laplace_matrix_free.cc
+++ b/tests/test_laplace_matrix_free.cc
@@ -24,6 +24,8 @@ class ExactSolution : public dealii::Function<dim>
 public:
   ExactSolution() = default;
 
+  virtual ~ExactSolution() override = default;
+
   double value(dealii::Point<dim> const &p,
                unsigned int const component = 0) const override;
 };

--- a/tests/test_restriction_matrix.cc
+++ b/tests/test_restriction_matrix.cc
@@ -42,6 +42,8 @@ public:
   {
   }
 
+  virtual ~DummyMeshEvaluator() override = default;
+
   void
   evaluate_global(dealii::DoFHandler<dim> &,
                   dealii::AffineConstraints<double> &,
@@ -171,6 +173,8 @@ class Source : public dealii::Function<dim>
 public:
   Source() = default;
 
+  virtual ~Source() override = default;
+
   virtual double value(dealii::Point<dim> const &p,
                        unsigned int const component = 0) const override final;
 };
@@ -186,6 +190,8 @@ class ConstantMaterialProperty : public dealii::Function<dim>
 {
 public:
   ConstantMaterialProperty() = default;
+
+  virtual ~ConstantMaterialProperty() override = default;
 
   virtual double value(dealii::Point<dim> const &,
                        unsigned int const = 0) const override final
@@ -205,6 +211,8 @@ public:
         _matrix(matrix)
   {
   }
+
+  virtual ~TestMeshEvaluator() override = default;
 
   void evaluate_global(dealii::DoFHandler<dim> &,
                        dealii::AffineConstraints<double> &,


### PR DESCRIPTION
This became an issue when trying to debug the multithread support in one place, so I decided to be more explicitly about `virtual` destructors everywhere.