### PR TITLE
Improve multithread support

### DIFF
--- a/include/mfmg/dealii/amge_host.templates.hpp
+++ b/include/mfmg/dealii/amge_host.templates.hpp
@@ -62,10 +62,10 @@ struct MatrixFreeAgglomerateOperator
   MatrixFreeAgglomerateOperator(MeshEvaluator const &mesh_evaluator,
                                 DoFHandler &dof_handler,
                                 dealii::AffineConstraints<double> &constraints)
-      : _mesh_evaluator(mesh_evaluator), _dof_handler(dof_handler),
+      : _mesh_evaluator(mesh_evaluator.clone()), _dof_handler(dof_handler),
         _constraints(constraints)
   {
-    _mesh_evaluator.matrix_free_initialize_agglomerate(dof_handler);
+    _mesh_evaluator->matrix_free_initialize_agglomerate(dof_handler);
   }
 
   /**
@@ -74,7 +74,7 @@ struct MatrixFreeAgglomerateOperator
   void vmult(dealii::Vector<double> &dst,
              dealii::Vector<double> const &src) const
   {
-    _mesh_evaluator.matrix_free_evaluate_agglomerate(src, dst);
+    _mesh_evaluator->matrix_free_evaluate_agglomerate(src, dst);
   }
 
   /**
@@ -85,7 +85,7 @@ struct MatrixFreeAgglomerateOperator
    */
   std::vector<double> get_diag_elements() const
   {
-    return _mesh_evaluator.matrix_free_get_agglomerate_diagonal(_constraints);
+    return _mesh_evaluator->matrix_free_get_agglomerate_diagonal(_constraints);
   }
 
   /**
@@ -102,7 +102,7 @@ private:
   /**
    * The actual operator wrapped.
    */
-  MeshEvaluator const &_mesh_evaluator;
+  std::unique_ptr<MeshEvaluator const> const _mesh_evaluator;
 
   /**
    * The dimension for the underlying mesh.
@@ -462,6 +462,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
   std::vector<std::vector<dealii::types::global_dof_index>> dof_indices_maps;
   std::vector<unsigned int> n_local_eigenvectors;
   CopyData copy_data;
+
   dealii::WorkStream::run(
       agglomerate_ids.begin(), agglomerate_ids.end(),
       [&](std::vector<unsigned int>::iterator const &agg_id,
@@ -518,6 +519,7 @@ void AMGe_host<dim, MeshEvaluator, VectorType>::setup_restrictor(
   std::vector<std::vector<dealii::types::global_dof_index>> dof_indices_maps;
   std::vector<unsigned int> n_local_eigenvectors;
   CopyData copy_data;
+
   dealii::WorkStream::run(
       agglomerate_ids.begin(), agglomerate_ids.end(),
       [&](std::vector<unsigned int>::iterator const &agg_id,

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -57,6 +57,16 @@ public:
   virtual ~DealIIMatrixFreeMeshEvaluator() override = default;
 
   /**
+   * Create a deep copy of this class such that initializing on another
+   * agglomerate works.
+   */
+  virtual std::unique_ptr<DealIIMatrixFreeMeshEvaluator> clone() const
+  {
+    ASSERT_THROW_NOT_IMPLEMENTED();
+    return std::make_unique<DealIIMatrixFreeMeshEvaluator>(*this);
+  }
+
+  /**
    * Return the class name as std::string.
    */
   std::string get_mesh_evaluator_type() const override final;

--- a/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
+++ b/include/mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp
@@ -58,7 +58,11 @@ public:
 
   /**
    * Create a deep copy of this class such that initializing on another
-   * agglomerate works.
+   * agglomerate works. This was introduced because calls to member functions
+   * matrix_free_initialize_agglomerate() and matrix_free_evaluate_agglomerate()
+   * (implemented in user provided classes deriving from
+   * DealIIMatrixFreeMeshEvaluator) are not thread-safe. There might be other
+   * options to solve this problem.
    */
   virtual std::unique_ptr<DealIIMatrixFreeMeshEvaluator> clone() const
   {

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -12,6 +12,7 @@
 #include <mfmg/common/instantiation.hpp>
 #include <mfmg/common/operator.hpp>
 #include <mfmg/dealii/amge_host.hpp>
+#include <mfmg/dealii/amge_host.templates.hpp>
 #include <mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp>
 #include <mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp>
 #include <mfmg/dealii/dealii_matrix_free_operator.hpp>
@@ -83,6 +84,7 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
     std::unique_ptr<dealii::TrilinosWrappers::SparseMatrix> eigenvector_matrix;
     std::unique_ptr<dealii::TrilinosWrappers::SparseMatrix>
         delta_eigenvector_matrix;
+
     amge.setup_restrictor(agglomerate_params, n_eigenvectors, tolerance,
                           *dealii_mesh_evaluator, locally_relevant_global_diag,
                           restrictor_matrix, eigenvector_matrix,
@@ -125,91 +127,91 @@ DealIIMatrixFreeHierarchyHelpers<dim, VectorType>::build_restrictor(
         std::vector<std::vector<dealii::TrilinosScalar>> values_per_row;
       } copy_data;
 
-      auto worker =
-          [&](const std::vector<std::vector<unsigned int>>::const_iterator
-                  &agglomerate_it,
-              ScratchData &, CopyData &local_copy_data) {
-            dealii::Triangulation<dim> agglomerate_triangulation;
-            std::map<typename dealii::Triangulation<dim>::active_cell_iterator,
-                     typename dealii::DoFHandler<dim>::active_cell_iterator>
-                patch_to_global_map;
-            amge.build_agglomerate_triangulation(*agglomerate_it,
-                                                 agglomerate_triangulation,
-                                                 patch_to_global_map);
-            if (patch_to_global_map.empty())
+      auto worker = [&](const std::vector<std::vector<unsigned int>>::
+                            const_iterator &agglomerate_it,
+                        ScratchData &, CopyData &local_copy_data) {
+        dealii::Triangulation<dim> agglomerate_triangulation;
+        std::map<typename dealii::Triangulation<dim>::active_cell_iterator,
+                 typename dealii::DoFHandler<dim>::active_cell_iterator>
+            patch_to_global_map;
+        amge.build_agglomerate_triangulation(
+            *agglomerate_it, agglomerate_triangulation, patch_to_global_map);
+        if (patch_to_global_map.empty())
+        {
+          return;
+        }
+
+        // Now that we have the triangulation, we can do the evaluation on
+        // the agglomerate
+        dealii::DoFHandler<dim> agglomerate_dof_handler(
+            agglomerate_triangulation);
+        agglomerate_dof_handler.distribute_dofs(
+            dealii_mesh_evaluator->get_dof_handler().get_fe());
+
+        // Put the result in the matrix
+        // Compute the map between the local and the global dof indices.
+        local_copy_data.rows.resize(n_local_eigenvectors);
+
+        local_copy_data.cols = amge.compute_dof_index_map(
+            patch_to_global_map, agglomerate_dof_handler);
+        auto const &dof_indices_map = local_copy_data.cols;
+        unsigned int const n_elem = dof_indices_map.size();
+
+        // We need a clean reset for the values we are going to store.
+        // Otherwise, we would accumulate values across patches
+        // corresponding to different degrees of freedom.
+        local_copy_data.values_per_row.resize(n_local_eigenvectors);
+        std::fill(local_copy_data.values_per_row.begin(),
+                  local_copy_data.values_per_row.end(),
+                  std::vector<dealii::TrilinosScalar>(n_elem));
+
+        unsigned int const i = agglomerate_it - agglomerates_vector.begin();
+
+        for (unsigned int j = 0; j < n_local_eigenvectors; ++j)
+        {
+          unsigned int const local_row = i * n_local_eigenvectors + j;
+          unsigned int const global_row =
+              eigenvector_matrix->locally_owned_range_indices()
+                  .nth_index_in_set(local_row);
+          // Get the vector used for the matrix-vector multiplication
+          dealii::Vector<ScalarType> delta_eig(n_elem);
+          if (is_halo_agglomerate)
+          {
+            for (unsigned int k = 0; k < n_elem; ++k)
             {
-              return;
+              delta_eig[k] =
+                  delta_eigenvector_matrix->el(global_row, dof_indices_map[k]) +
+                  eigenvector_matrix->el(global_row, dof_indices_map[k]);
             }
-
-            // Now that we have the triangulation, we can do the evaluation on
-            // the agglomerate
-            dealii::DoFHandler<dim> agglomerate_dof_handler(
-                agglomerate_triangulation);
-            agglomerate_dof_handler.distribute_dofs(
-                dealii_mesh_evaluator->get_dof_handler().get_fe());
-
-            // Put the result in the matrix
-            // Compute the map between the local and the global dof indices.
-            local_copy_data.rows.resize(n_local_eigenvectors);
-
-            local_copy_data.cols = amge.compute_dof_index_map(
-                patch_to_global_map, agglomerate_dof_handler);
-            auto const &dof_indices_map = local_copy_data.cols;
-            unsigned int const n_elem = dof_indices_map.size();
-
-            // We need a clean reset for the values we are going to store.
-            // Otherwise, we would accumulate values across patches
-            // corresponding to different degrees of freedom.
-            local_copy_data.values_per_row.resize(n_local_eigenvectors);
-            std::fill(local_copy_data.values_per_row.begin(),
-                      local_copy_data.values_per_row.end(),
-                      std::vector<dealii::TrilinosScalar>(n_elem));
-
-            unsigned int const i = agglomerate_it - agglomerates_vector.begin();
-
-            for (unsigned int j = 0; j < n_local_eigenvectors; ++j)
+          }
+          else
+          {
+            for (unsigned int k = 0; k < n_elem; ++k)
             {
-              unsigned int const local_row = i * n_local_eigenvectors + j;
-              unsigned int const global_row =
-                  eigenvector_matrix->locally_owned_range_indices()
-                      .nth_index_in_set(local_row);
-              // Get the vector used for the matrix-vector multiplication
-              dealii::Vector<ScalarType> delta_eig(n_elem);
-              if (is_halo_agglomerate)
-              {
-                for (unsigned int k = 0; k < n_elem; ++k)
-                {
-                  delta_eig[k] =
-                      delta_eigenvector_matrix->el(global_row,
-                                                   dof_indices_map[k]) +
-                      eigenvector_matrix->el(global_row, dof_indices_map[k]);
-                }
-              }
-              else
-              {
-                for (unsigned int k = 0; k < n_elem; ++k)
-                {
-                  delta_eig[k] = delta_eigenvector_matrix->el(
-                      global_row, dof_indices_map[k]);
-                }
-              }
-
-              // Perform the matrix-vector multiplication
-              dealii::Vector<ScalarType> correction(n_elem);
-              dealii_mesh_evaluator->matrix_free_initialize_agglomerate(
-                  agglomerate_dof_handler);
-              dealii_mesh_evaluator->matrix_free_evaluate_agglomerate(
-                  delta_eig, correction);
-
-              // Store the values the delta correction matrix is to be filled
-              // with.
-              local_copy_data.rows[j] = global_row;
-              std::transform(correction.begin(), correction.end(),
-                             local_copy_data.values_per_row[j].begin(),
-                             local_copy_data.values_per_row[j].begin(),
-                             std::plus<double>());
+              delta_eig[k] =
+                  delta_eigenvector_matrix->el(global_row, dof_indices_map[k]);
             }
-          };
+          }
+
+          // Perform the matrix-vector multiplication
+          dealii::Vector<ScalarType> correction(n_elem);
+          dealii::AffineConstraints<double> agglomerate_constraints;
+          using AgglomerateOperator =
+              MatrixFreeAgglomerateOperator<DealIIMatrixFreeMeshEvaluator<dim>>;
+          AgglomerateOperator agglomerate_operator(*dealii_mesh_evaluator,
+                                                   agglomerate_dof_handler,
+                                                   agglomerate_constraints);
+          agglomerate_operator.vmult(correction, delta_eig);
+
+          // Store the values the delta correction matrix is to be filled
+          // with.
+          local_copy_data.rows[j] = global_row;
+          std::transform(correction.begin(), correction.end(),
+                         local_copy_data.values_per_row[j].begin(),
+                         local_copy_data.values_per_row[j].begin(),
+                         std::plus<double>());
+        }
+      };
 
       auto copier = [&](const CopyData &local_copy_data) {
         for (unsigned int i = 0; i < local_copy_data.rows.size(); ++i)

--- a/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
+++ b/source/dealii/dealii_matrix_free_hierarchy_helpers.cc
@@ -12,6 +12,8 @@
 #include <mfmg/common/instantiation.hpp>
 #include <mfmg/common/operator.hpp>
 #include <mfmg/dealii/amge_host.hpp>
+// Needed for MatrixFreeAgglomerateOperator, the definition should be moved
+// elsewhere.
 #include <mfmg/dealii/amge_host.templates.hpp>
 #include <mfmg/dealii/dealii_matrix_free_hierarchy_helpers.hpp>
 #include <mfmg/dealii/dealii_matrix_free_mesh_evaluator.hpp>

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
     dim = vm["dim"].as<int>();
   mfmg::ASSERT(dim == 2 || dim == 3, "Dimension must be 2 or 3");
 
-  bool matrix_free = false;
+  bool matrix_free = true;
   if (vm.count("matrix_free"))
     matrix_free = vm["matrix_free"].as<bool>();
 
@@ -274,7 +274,6 @@ int main(int argc, char *argv[])
   if (matrix_free)
   {
     params->put("smoother.type", "Chebyshev");
-
     if (dim == 2)
     {
       switch (fe_degree)
@@ -418,6 +417,7 @@ int main(int argc, char *argv[])
   }
   else
   {
+    dealii::MultithreadInfo::set_thread_limit(1);
     if (dim == 2)
       matrix_based_two_grids<2>(params);
     else

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -217,8 +217,7 @@ int main(int argc, char *argv[])
 {
   namespace boost_po = boost::program_options;
 
-  MPI_Init(&argc, &argv);
-  dealii::MultithreadInfo::set_thread_limit(1);
+  dealii::Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
 
   boost_po::options_description cmd("Available options");
   cmd.add_options()("help,h", "produce help message");
@@ -424,8 +423,6 @@ int main(int argc, char *argv[])
     else
       matrix_based_two_grids<3>(params);
   }
-
-  MPI_Finalize();
 
   return 0;
 }

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -19,6 +19,8 @@ bool init_function() { return true; }
 
 int main(int argc, char *argv[])
 {
+  // Set the maximum number of threads used to the minimum of the number of
+  // cores reported by TBB and the environment variable DEAL_II_NUM_THREADS.
   dealii::Utilities::MPI::MPI_InitFinalize mpi_init(
       argc, argv, dealii::numbers::invalid_unsigned_int);
 

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -36,6 +36,15 @@
 #include "main.cc"
 #include "test_hierarchy_helpers.hpp"
 
+// In a lot of places in this file, we explicitly set the number of threads to
+// use since some of the tests cases don't work with multiple threads yet. This
+// works as follow: dealii::MultithreadInfo::set_thread_limit sets the number of
+// threads to the minimum its the argument and the environment variable
+// DEAL_II_NUM_THREADS. TBB is asked for the maximum nuber of cores if the
+// minimum is dealii::numbers::invalid_unsigned_int. Consequently,
+// MultithreadInfo::set_thread_limit(numbers::invalid_unsigned int) sets the
+// number of threads to the ones specified in the environment variable.
+
 namespace bdata = boost::unit_test::data;
 namespace tt = boost::test_tools;
 

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -203,7 +203,8 @@ BOOST_AUTO_TEST_CASE(benchmark)
 
 BOOST_AUTO_TEST_CASE(benchmark_mf)
 {
-  dealii::MultithreadInfo::set_thread_limit(1);
+  dealii::MultithreadInfo::set_thread_limit(
+      dealii::numbers::invalid_unsigned_int);
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -309,7 +309,22 @@ public:
   {
   }
 
+  TestMFMeshEvaluator(
+      TestMFMeshEvaluator<dim, fe_degree, ScalarType> const &_other_evaluator)
+      : mfmg::DealIIMatrixFreeMeshEvaluator<dim>(*this),
+        _material_property(_other_evaluator._material_property),
+        _fe(_other_evaluator._fe),
+        _laplace_operator(_other_evaluator._laplace_operator)
+  {
+  }
+
   virtual ~TestMFMeshEvaluator() override = default;
+
+  virtual std::unique_ptr<mfmg::DealIIMatrixFreeMeshEvaluator<dim>>
+  clone() const override
+  {
+    return std::make_unique<TestMFMeshEvaluator>(*this);
+  }
 
   virtual void
   matrix_free_evaluate_agglomerate(dealii::Vector<double> const &src,

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -309,6 +309,10 @@ public:
   {
   }
 
+  // We need a copy constructor since the evaluator has to cloned for each
+  // agglomerate. Here, we just copy the minimum number of member variables
+  // required. In particular, we should not need to copy mutable members since
+  // they are set up in matrix_free_initialize_agglomerate only.
   TestMFMeshEvaluator(
       TestMFMeshEvaluator<dim, fe_degree, ScalarType> const &_other_evaluator)
       : mfmg::DealIIMatrixFreeMeshEvaluator<dim>(*this),


### PR DESCRIPTION
Part of #185. This pull request allows `hierarchy_driver` to run multithreaded. The main modification is that we have to copy the `Evaluator` for each agglomerate to avoid race conditions.

I have no idea why the formatting in `include/mfmg/dealii/dealii_mesh_evaluator.hpp` changed that much.