### PR TITLE
Allow using SolverCG in hierarchy_driver

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,36 @@ MFMG_ADD_TEST(test_lanczos 1)
 MFMG_ADD_TEST(test_laplace 1 2 4)
 MFMG_ADD_TEST(test_laplace_matrix_free 1 2 4)
 MFMG_ADD_TEST(test_hierarchy 1 2 4)
-MFMG_ADD_TEST(hierarchy_driver 1 2 4)
 MFMG_ADD_TEST(test_agglomerate 1 2 4)
 MFMG_ADD_TEST(test_eigenvectors 1)
 MFMG_ADD_TEST(test_restriction_matrix 1 2 4)
 MFMG_ADD_TEST(test_utils 1)
+
+ADD_EXECUTABLE(hierarchy_driver ${CMAKE_CURRENT_SOURCE_DIR}/hierarchy_driver.cc ${TESTS_SOURCES})
+TARGET_INCLUDE_AND_LINK(hierarchy_driver)
+SET_TARGET_PROPERTIES(hierarchy_driver PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  )
+FOREACH(NPROC 1;2;4)
+  ADD_TEST(
+    NAME hierarchy_driver_${NPROC}
+    COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NPROC} ./hierarchy_driver -m 0
+    )
+  SET_TESTS_PROPERTIES(hierarchy_driver_${NPROC} PROPERTIES
+      PROCESSORS ${NPROC}
+      )
+ENDFOREACH()
+FOREACH(NPROC 1;2;4)
+  ADD_TEST(
+    NAME hierarchy_driver_mf_${NPROC}
+    COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NPROC} ./hierarchy_driver -m 1
+    )
+  SET_TESTS_PROPERTIES(hierarchy_driver_mf_${NPROC} PROPERTIES
+      PROCESSORS ${NPROC}
+      )
+ENDFOREACH()
 
 IF(${MFMG_ENABLE_CUDA})
   MFMG_ADD_CUDA_TEST(test_utils_device 1 2 4)


### PR DESCRIPTION
This pull request makes `hierarchy_driver` look closer to what we are using for profiling.
Essentially, we just test for `Hierarchy` as a preconditioner for `CG` instead of as a solver on its own.

Apart from that also some of the default values are changed. We use polynomial degree 4 rather than one, and enable `Lanczos` as eigensolver and use the `FastAP` interface.