### PR TITLE
Fix DiscontinuousMaterialProperty

### DIFF
--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -598,15 +598,6 @@ BOOST_AUTO_TEST_CASE(fast_multiply_transpose_mf)
                    tt::tolerance(1e-9));
 }
 
-template <int dim>
-class ConstantMaterialProperty;
-template <int dim>
-class LinearMaterialProperty;
-template <int dim>
-class LinearXMaterialProperty;
-template <int dim>
-class DiscontinuousMaterialProperty;
-
 using material_properties =
     std::tuple<ConstantMaterialProperty<2>, LinearMaterialProperty<2>,
                LinearXMaterialProperty<2>, DiscontinuousMaterialProperty<2>>;

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(fast_multiply_transpose)
   MPI_Comm comm = MPI_COMM_WORLD;
 
   using DVector = dealii::LinearAlgebra::distributed::Vector<double>;
-  int constexpr dim = mfmg::DealIIMeshEvaluator<2>::_dim;
+  int constexpr dim = 2;
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(fast_multiply_transpose_mf)
   MPI_Comm comm = MPI_COMM_WORLD;
 
   using DVector = dealii::LinearAlgebra::distributed::Vector<double>;
-  int constexpr dim = mfmg::DealIIMatrixFreeMeshEvaluator<2>::_dim;
+  int constexpr dim = 2;
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);
@@ -609,7 +609,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_material_properties, MaterialProperty,
   MPI_Comm comm = MPI_COMM_WORLD;
 
   using DVector = dealii::LinearAlgebra::distributed::Vector<double>;
-  int constexpr dim = mfmg::DealIIMatrixFreeMeshEvaluator<2>::_dim;
+  int constexpr dim = 2;
 
   auto params = std::make_shared<boost::property_tree::ptree>();
   boost::property_tree::info_parser::read_info("hierarchy_input.info", *params);

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -154,7 +154,6 @@ public:
   value(dealii::Point<dim, dealii::VectorizedArray<double>> const &p,
         unsigned int const = 0) const override
   {
-    auto const one = dealii::make_vectorized_array<double>(1.);
     auto dim_scale = dealii::make_vectorized_array<double>(0);
     for (unsigned int i = 0;
          i < dealii::VectorizedArray<double>::n_array_elements; ++i)

--- a/tests/test_hierarchy_helpers.hpp
+++ b/tests/test_hierarchy_helpers.hpp
@@ -155,11 +155,19 @@ public:
         unsigned int const = 0) const override
   {
     auto const one = dealii::make_vectorized_array<double>(1.);
-    unsigned int dim_scale = 0;
-    for (unsigned int d = 0; d < dim; ++d)
-      dim_scale += static_cast<unsigned int>(std::floor(p[d][0] * 100)) % 2;
+    auto dim_scale = dealii::make_vectorized_array<double>(0);
+    for (unsigned int i = 0;
+         i < dealii::VectorizedArray<double>::n_array_elements; ++i)
+      for (unsigned int d = 0; d < dim; ++d)
+        dim_scale[i] +=
+            static_cast<unsigned int>(std::floor(100. * p[d][i])) % 2;
 
-    return (dim_scale == dim ? 100. * one : 10. * one);
+    dealii::VectorizedArray<double> return_value;
+    for (unsigned int i = 0;
+         i < dealii::VectorizedArray<double>::n_array_elements; ++i)
+      return_value[i] = (dim_scale[i] == dim ? 100. : 10.);
+
+    return return_value;
   }
 
   virtual double value(dealii::Point<dim> const &p,


### PR DESCRIPTION
This change makes sure that we are indeed using the same coefficients for the matrix-free and the matrix-based case. Fixes #199.