### PR TITLE
Reuse eigenvectors as initial guess for LOBPCG

### DIFF
--- a/include/mfmg/dealii/anasazi.hpp
+++ b/include/mfmg/dealii/anasazi.hpp
@@ -27,13 +27,14 @@ public:
   AnasaziSolver(OperatorType const &op);
 
   AnasaziSolver(AnasaziSolver<OperatorType, VectorType> const &) = delete;
+
   AnasaziSolver<OperatorType, VectorType> &
   operator=(AnasaziSolver<OperatorType, VectorType> const &) = delete;
 
   // Solve the eigenproblem
   std::tuple<std::vector<double>, std::vector<VectorType>>
   solve(boost::property_tree::ptree const &params,
-        VectorType initial_guess) const;
+        std::vector<std::shared_ptr<VectorType>> const &initial_guess) const;
 
 private:
   OperatorType const &_op; // reference to operator object to use

--- a/include/mfmg/dealii/multivector.hpp
+++ b/include/mfmg/dealii/multivector.hpp
@@ -31,9 +31,18 @@ public:
       v = std::make_shared<VectorType>(vector_size);
     });
   }
+
+  MultiVector(std::vector<std::shared_ptr<VectorType>> const &vectors)
+      : _vectors(vectors)
+  {
+  }
+
   int size() const { return _vectors.empty() ? 0 : _vectors[0]->size(); }
+
   int n_vectors() const { return _vectors.size(); }
+
   std::shared_ptr<VectorType> &operator[](int index) { return _vectors[index]; }
+
   std::shared_ptr<VectorType> const &operator[](int index) const
   {
     return _vectors[index];

--- a/source/dealii/amge_host.cc
+++ b/source/dealii/amge_host.cc
@@ -43,7 +43,8 @@ template class mfmg::AMGe_host<
               typename dealii::Triangulation<DIM>::active_cell_iterator,       \
               typename dealii::DoFHandler<DIM>::active_cell_iterator> const    \
               &patch_to_global_map,                                            \
-          MESH_EVALUATOR<DIM> const &evaluator, int) const;
+          MESH_EVALUATOR<DIM> const &evaluator,                                \
+          mfmg::LobpcgScratchData const &, int) const;
 
 INSTANTIATE_COMPUTE_LOCAL_EIGENVECTORS(2, mfmg::DealIIMeshEvaluator)
 INSTANTIATE_COMPUTE_LOCAL_EIGENVECTORS(3, mfmg::DealIIMeshEvaluator)

--- a/tests/data/hierarchy_input.info
+++ b/tests/data/hierarchy_input.info
@@ -2,6 +2,9 @@ eigensolver
 {
   "number of eigenvectors" 2
   tolerance 1e-14
+  ; When using LOBPGC, the following input parameters are available:
+  ; use_initial_guess true (default is false)
+  ; verbosity 0
 }
 
 smoother

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
   int const fe_degree = params->get<unsigned int>("laplace.fe_degree", 4);
   params->put("fast_ap", true);
   params->put("eigensolver.type", "anasazi");
-  params->put("eigensolver.tolerance", 1e-2);
+  params->put("eigensolver.tolerance", 1e-3);
 
   double solver_tolerance = 1.e-6;
   if (vm.count("tolerance"))

--- a/tests/hierarchy_driver.cc
+++ b/tests/hierarchy_driver.cc
@@ -269,6 +269,7 @@ int main(int argc, char *argv[])
   int const fe_degree = params->get<unsigned int>("laplace.fe_degree", 4);
   params->put("fast_ap", true);
   params->put("eigensolver.type", "anasazi");
+  params->put("eigensolver.tolerance", 1e-2);
 
   double solver_tolerance = 1.e-6;
   if (vm.count("tolerance"))

--- a/tests/test_eigenvectors.cc
+++ b/tests/test_eigenvectors.cc
@@ -100,7 +100,8 @@ BOOST_AUTO_TEST_CASE(diagonal, *ut::tolerance(1e-12))
   std::vector<dealii::types::global_dof_index> dof_indices_map;
   std::tie(eigenvalues, eigenvectors, diag_elements, dof_indices_map) =
       amge.compute_local_eigenvectors(n_eigenvectors, 1e-13, triangulation,
-                                      patch_to_global_map, evaluator);
+                                      patch_to_global_map, evaluator,
+                                      mfmg::LobpcgScratchData());
 
   std::vector<dealii::types::global_dof_index> ref_dof_indices_map(
       dof_handler.n_dofs());
@@ -203,7 +204,8 @@ BOOST_AUTO_TEST_CASE(diagonal_constraint, *ut::tolerance(1e-12))
   std::vector<dealii::types::global_dof_index> dof_indices_map;
   std::tie(eigenvalues, eigenvectors, diag_elements, dof_indices_map) =
       amge.compute_local_eigenvectors(n_eigenvectors, 1e-13, triangulation,
-                                      patch_to_global_map, evaluator);
+                                      patch_to_global_map, evaluator,
+                                      mfmg::LobpcgScratchData());
 
   std::vector<dealii::types::global_dof_index> ref_dof_indices_map(
       dof_handler.n_dofs());

--- a/tests/test_hierarchy.cc
+++ b/tests/test_hierarchy.cc
@@ -277,7 +277,8 @@ BOOST_DATA_TEST_CASE(
         bdata::make({"None", "Reverse Cuthill_McKee"}) *
         bdata::make<std::string>({"DealIIMeshEvaluator",
                                   "DealIIMatrixFreeMeshEvaluator"}) *
-        bdata::make<std::string>({"arpack", "lanczos", "anasazi"}),
+        bdata::make<std::string>({"arpack", "lanczos", "anasazi",
+                                  "anasazi_init_guess"}),
     mesh, distort_random, reordering, mesh_evaluator_type, eigensolver)
 {
   dealii::MultithreadInfo::set_thread_limit(1);
@@ -304,6 +305,15 @@ BOOST_DATA_TEST_CASE(
     params->put("laplace.mesh", mesh);
     params->put("laplace.distort_random", distort_random);
     params->put("laplace.reordering", reordering);
+
+    if (eigensolver == "anasazi" || eigensolver == "anasazi_init_guess")
+      params->put("eigensolver.tolerance", 1e-2);
+
+    if (eigensolver == "anasazi_init_guess")
+    {
+      params->put("eigensolver.type", "anasazi");
+      params->put("eigensolver.use_initial_guess", true);
+    }
 
     if (is_matrix_free && eigensolver == "arpack")
     {
@@ -372,6 +382,27 @@ BOOST_DATA_TEST_CASE(
     ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "anasazi" , "matrix-free")] = 0.3029292535;
     ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "anasazi" , "matrix-full")] = 0.0970940159;
     ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "anasazi" , "matrix-free")] = 0.3029292535;
+
+    // FIXME Running ./test_hierarchy instead of ctest -R test_hierarchy gives a
+    // better convergence rate. Tightening the tolerance on anasazi-does reduces
+    // the difference but the cost of tightening the convergence is too great to
+    // do it in the tests. 
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "anasazi_init_guess" , "matrix-full")] = 0.0238359183;// 0.0200805406;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "None"                  , "anasazi_init_guess" , "matrix-free")] = 0.0822670712;// 0.0781625982;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-full")] = 0.0238359183;// 0.0200805406;
+    ref_solution[std::make_tuple("hyper_cube" , "no_distort" , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-free")] = 0.0822670712;// 0.0781625982;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "anasazi_init_guess" , "matrix-full")] = 0.0222672564;// 0.0219936421;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "None"                  , "anasazi_init_guess" , "matrix-free")] = 0.0851825995;// 0.0851825995;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-full")] = 0.0222672564;// 0.0219936421;
+    ref_solution[std::make_tuple("hyper_cube" , "distort"    , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-free")] = 0.0851825995;// 0.0851825995;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "anasazi_init_guess" , "matrix-full")] = 0.0853022267;// 0.0820852559;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "None"                  , "anasazi_init_guess" , "matrix-free")] = 0.3062882615;// 0.3062882615;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-full")] = 0.0853022267;// 0.0820852559;
+    ref_solution[std::make_tuple("hyper_ball" , "no_distort" , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-free")] = 0.3062882615;// 0.3062882615;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "anasazi_init_guess" , "matrix-full")] = 0.0758339950;// 0.0839258130;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "None"                  , "anasazi_init_guess" , "matrix-free")] = 0.3029292535;// 0.3029292535;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-full")] = 0.0758339950;// 0.0839258130;
+    ref_solution[std::make_tuple("hyper_ball" , "distort"    , "Reverse Cuthill_McKee" , "anasazi_init_guess" , "matrix-free")] = 0.3029292535;// 0.3029292535;
     // clang-format on
 
     BOOST_TEST(


### PR DESCRIPTION
The basic idea here is to use `ScratchData` to update the initial guess for LOBPCG. `ScratchData` is local to a thread which means that using a different number of threads will change the initial guess for a given agglomerate. Other than that, I had to change the constructor of `mfmg::MultiVector` to use a `std::vector` instead of a `VectorType`. In my test (in debug mode), the setup was 15 to 20% faster.